### PR TITLE
destdir: build as non-root, without hardcoded IDs.

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -154,7 +154,6 @@ auto-uid.o
 auto-uid
 auto-gid.o
 auto-gid
-auto_uids.c
 auto_uids.o
 qmail-lspawn
 qmail-getpw.o
@@ -385,3 +384,10 @@ forgeries.0
 man
 setup
 check
+auto_destdir.c
+auto_destdir.o
+auto_usergroupnames.h
+hier_destdir.c
+hier_destdir.o
+install-destdir.o
+install-destdir

--- a/auto_uids.c
+++ b/auto_uids.c
@@ -1,0 +1,54 @@
+#include <pwd.h>
+#include <grp.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include "auto_uids.h"
+#include "auto_usergroupnames.h"
+#include "qlx.h"
+
+struct group *getgrnam();
+struct passwd *getpwnam();
+
+static int ids[] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+
+static int
+name2uid(name)
+char *name;
+{
+  struct passwd *pw;
+  pw = getpwnam(name);
+  if (!pw) _exit(QLX_NOALIAS);
+  return (int)(pw->pw_uid);
+}
+
+static int
+name2gid(name)
+char *name;
+{
+  struct group *gr;
+  gr = getgrnam(name);
+  if (!gr) _exit(QLX_NOALIAS);
+  return (int)(gr->gr_gid);
+}
+
+int
+qmail_id_lookup(id)
+int id;
+{
+  if (ids[id] >= 0) return ids[id];
+
+  switch(id) {
+  case ID_OWNER:   ids[id] = name2uid(auto_usero); break;
+  case ID_ALIAS:   ids[id] = name2uid(auto_usera); break;
+  case ID_DAEMON:  ids[id] = name2uid(auto_userd); break;
+  case ID_LOG:     ids[id] = name2uid(auto_userl); break;
+  case ID_PASSWD:  ids[id] = name2uid(auto_userp); break;
+  case ID_QUEUE:   ids[id] = name2uid(auto_userq); break;
+  case ID_REMOTE:  ids[id] = name2uid(auto_userr); break;
+  case ID_SEND:    ids[id] = name2uid(auto_users); break;
+  case ID_QMAIL:   ids[id] = name2gid(auto_groupq); break;
+  case ID_NOFILES: ids[id] = name2gid(auto_groupn); break;
+  default: _exit(QLX_NOALIAS);
+  }
+  return ids[id];
+}

--- a/auto_uids.h
+++ b/auto_uids.h
@@ -1,16 +1,29 @@
 #ifndef AUTO_UIDS_H
 #define AUTO_UIDS_H
 
-extern int auto_uida;
-extern int auto_uidd;
-extern int auto_uidl;
-extern int auto_uido;
-extern int auto_uidp;
-extern int auto_uidq;
-extern int auto_uidr;
-extern int auto_uids;
+#define ID_OWNER   0
+#define ID_ALIAS   1
+#define ID_DAEMON  2
+#define ID_LOG     3
+#define ID_PASSWD  4
+#define ID_QUEUE   5
+#define ID_REMOTE  6
+#define ID_SEND    7
+#define ID_QMAIL   8
+#define ID_NOFILES 9
 
-extern int auto_gidn;
-extern int auto_gidq;
+#define auto_uido qmail_id_lookup(ID_OWNER)
+#define auto_uida qmail_id_lookup(ID_ALIAS)
+#define auto_uidd qmail_id_lookup(ID_DAEMON)
+#define auto_uidl qmail_id_lookup(ID_LOG)
+#define auto_uidp qmail_id_lookup(ID_PASSWD)
+#define auto_uidq qmail_id_lookup(ID_QUEUE)
+#define auto_uidr qmail_id_lookup(ID_REMOTE)
+#define auto_uids qmail_id_lookup(ID_SEND)
+
+#define auto_gidq qmail_id_lookup(ID_QMAIL)
+#define auto_gidn qmail_id_lookup(ID_NOFILES)
+
+extern int qmail_id_lookup();
 
 #endif

--- a/conf-destdir
+++ b/conf-destdir
@@ -1,0 +1,5 @@
+/var/tmp/qmail-destdir
+
+This is the qmail installation staging directory. It can be the same as
+the qmail home directory (conf-qmail), if you want. If it's somewhere
+else writable by non-root, you can build as non-root.

--- a/fake_chown.h
+++ b/fake_chown.h
@@ -1,0 +1,11 @@
+#ifndef FAKE_CHOWN_H
+#define FAKE_CHOWN_H
+
+/*
+ * Included only by install.c, which we don't want setting permissions
+ * Permissions will be set by ./install-destdir
+ */
+
+int chown(const char *p, unsigned int o, unsigned int g) { return 0; }
+
+#endif

--- a/fake_uids.h
+++ b/fake_uids.h
@@ -1,0 +1,22 @@
+#ifndef FAKE_UIDS_H
+#define FAKE_UIDS_H
+
+/*
+ * Included only by hier.c, which is linked only into ./install
+ * These values don't matter there, as it doesn't try to set permissions
+ * Permissions are set by ./install-destdir (linked with hier_destdir.c)
+ */
+
+#define auto_uido -79
+#define auto_uida -78
+#define auto_uidd -77
+#define auto_uidl -76
+#define auto_uidp -75
+#define auto_uidq -74
+#define auto_uidr -73
+#define auto_uids -72
+
+#define auto_gidq -71
+#define auto_gidn -70
+
+#endif

--- a/hier.c
+++ b/hier.c
@@ -1,6 +1,6 @@
 #include "auto_qmail.h"
 #include "auto_split.h"
-#include "auto_uids.h"
+#include "fake_uids.h"
 #include "fmt.h"
 #include "fifo.h"
 

--- a/install-destdir.c
+++ b/install-destdir.c
@@ -4,13 +4,12 @@
 #include "open.h"
 #include "readwrite.h"
 #include "exit.h"
-#include "fake_chown.h"
+#include "str.h"
+#include "env.h"
 
 extern void hier();
 
-#define FATAL "install: fatal: "
-
-int fdsourcedir = -1;
+#define FATAL "install-destdir: fatal: "
 
 void h(home,uid,gid,mode)
 char *home;
@@ -63,9 +62,7 @@ int mode;
     strerr_die6sys(111,FATAL,"unable to chmod ",home,"/",fifo,": ");
 }
 
-char inbuf[SUBSTDIO_INSIZE];
 char outbuf[SUBSTDIO_OUTSIZE];
-substdio ssin;
 substdio ssout;
 
 void c(home,subdir,file,uid,gid,mode)
@@ -76,42 +73,10 @@ int uid;
 int gid;
 int mode;
 {
-  int fdin;
-  int fdout;
-
-  if (fchdir(fdsourcedir) == -1)
-    strerr_die2sys(111,FATAL,"unable to switch back to source directory: ");
-
-  fdin = open_read(file);
-  if (fdin == -1)
-    strerr_die4sys(111,FATAL,"unable to read ",file,": ");
-  substdio_fdbuf(&ssin,read,fdin,inbuf,sizeof inbuf);
-
   if (chdir(home) == -1)
     strerr_die4sys(111,FATAL,"unable to switch to ",home,": ");
   if (chdir(subdir) == -1)
     strerr_die6sys(111,FATAL,"unable to switch to ",home,"/",subdir,": ");
-
-  fdout = open_trunc(file);
-  if (fdout == -1)
-    strerr_die6sys(111,FATAL,"unable to write .../",subdir,"/",file,": ");
-  substdio_fdbuf(&ssout,write,fdout,outbuf,sizeof outbuf);
-
-  switch(substdio_copy(&ssout,&ssin)) {
-    case -2:
-      strerr_die4sys(111,FATAL,"unable to read ",file,": ");
-    case -3:
-      strerr_die6sys(111,FATAL,"unable to write .../",subdir,"/",file,": ");
-  }
-
-  close(fdin);
-  if (substdio_flush(&ssout) == -1)
-    strerr_die6sys(111,FATAL,"unable to write .../",subdir,"/",file,": ");
-  if (fsync(fdout) == -1)
-    strerr_die6sys(111,FATAL,"unable to write .../",subdir,"/",file,": ");
-  if (close(fdout) == -1) /* NFS silliness */
-    strerr_die6sys(111,FATAL,"unable to write .../",subdir,"/",file,": ");
-
   if (chown(file,uid,gid) == -1)
     strerr_die6sys(111,FATAL,"unable to chown .../",subdir,"/",file,": ");
   if (chmod(file,mode) == -1)
@@ -155,10 +120,6 @@ int mode;
 
 void main()
 {
-  fdsourcedir = open_read(".");
-  if (fdsourcedir == -1)
-    strerr_die2sys(111,FATAL,"unable to open current directory: ");
-
   umask(077);
   hier();
   _exit(0);


### PR DESCRIPTION
This is my destdir patch from <https://schmonz.com/qmail/destdir/>. With
it, binary packages built on one system can run on any other system of
matching OS and architecture without also requiring matching numeric
UIDs and GIDs.

This patch supports our explicit goal "Being easily packaged by OS
integrators". I added it to pkgsrc 2 years ago, and they've had working
binary qmail packages ever since. My production mail server runs one.