### PR TITLE
qmail-inject: do not parse header recipients if "-a" is given

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+20190903 code: do not parse header recipients for "qmail-inject -a"
 20190826 code: if $QMAILREMOTE is set, it's invoked instead of qmail-remote.
 20190822 cleanup: remove unused dnsmxip.
 20190822 cleanup: remove unused dnscname.

--- a/qmail-inject.c
+++ b/qmail-inject.c
@@ -358,11 +358,14 @@ stralloc *h;
  
   switch(htype) {
     case H_TO: case H_CC:
-      rw = rwtocc; break;
+      if (flagrh) rw = rwtocc;
+      break;
     case H_BCC: case H_APPARENTLYTO:
-      rw = rwhr; break;
+      if (flagrh) rw = rwhr;
+      break;
     case H_R_TO: case H_R_CC: case H_R_BCC:
-      rw = rwhrr; break;
+      if (flagrh) rw = rwhrr;
+      break;
     case H_RETURNPATH:
       rw = rwreturn; break;
     case H_SENDER: case H_FROM: case H_REPLYTO:


### PR DESCRIPTION
qmail-inject can parse the message header to determine the recipients of a mail. You can also pass it a list of recipients on command line so it will ignore the recipients stated in the header. This is e.g. used when you redirect a mail by a .qmail file. But even if those recipients will not be used the header fields will still be parsed and a bounce is generated on failure.

If a mail is injected from network with the broken header field

  To: foo: bar, baz

then this would be delivered fine as the recipient is given in the SMTP transmission. If it could not be directly delivered but is forwarded to another user by a .qmail file or a virtualdomain alias then this mail is passed through "qmail-inject -a newrecipient". Nevertheless the header fields are parsed, the error is raised and the message is bounced. This leads to ugly bounces with the message "qmail-inject: fatal: unable to parse this line:". Since the message is of course spam the bounce will bounce again and annoy the postmaster. This patch changes qmail-inject to totally ignore the lines with recipients (To:, Cc:, Bcc) if the recipients were passed as arguments. In this case the mail will be routed to the original recipient and can there be handled.