### PR TITLE
Fix build on utmpx-only systems, such as FreeBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -685,6 +685,13 @@ chkshsgr warn-shsgr tryshsgr.c compile load
 	hasshsgr.h
 	rm -f tryshsgr.o tryshsgr
 
+hasutmpx.h: \
+tryutmpx.c compile load
+	( ( ./compile tryutmpx.c && ./load tryutmpx ) >/dev/null \
+	2>&1 \
+	&& echo \#define HASUTMPX 1 || exit 0 ) > hasutmpx.h
+	rm -f tryutmpx.o tryutmpx
+
 haswaitp.h: \
 trywaitp.c compile load
 	( ( ./compile trywaitp.c && ./load trywaitp ) >/dev/null \
@@ -1071,7 +1078,8 @@ qbiff.1
 
 qbiff.o: \
 compile qbiff.c readwrite.h stralloc.h gen_alloc.h substdio.h subfd.h \
-substdio.h open.h byte.h str.h headerbody.h hfield.h env.h exit.h
+substdio.h open.h byte.h str.h headerbody.h hfield.h env.h exit.h \
+hasutmpx.h
 	./compile qbiff.c
 
 qmail-clean: \

--- a/TARGETS
+++ b/TARGETS
@@ -385,3 +385,4 @@ forgeries.0
 man
 setup
 check
+hasutmpx.h

--- a/qbiff.c
+++ b/qbiff.c
@@ -1,11 +1,16 @@
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "hasutmpx.h"
+#ifdef HASUTMPX
+#include <utmpx.h>
+#else
 #include <utmp.h>
 #ifndef UTMP_FILE
 #ifdef _PATH_UTMP
 #define UTMP_FILE _PATH_UTMP
 #else
 #define UTMP_FILE "/etc/utmp"
+#endif
 #endif
 #endif
 #include "readwrite.h"
@@ -20,15 +25,22 @@
 #include "env.h"
 #include "exit.h"
 
+#ifndef HASUTMPX
 substdio ssutmp;
 char bufutmp[sizeof(struct utmp) * 16];
 int fdutmp;
+#endif
 substdio sstty;
 char buftty[1024];
 int fdtty;
 
+#ifdef HASUTMPX
+struct utmpx *ut;
+char line[sizeof(ut->ut_line) + 1];
+#else
 struct utmp ut;
 char line[sizeof(ut.ut_line) + 1];
+#endif
 stralloc woof = {0};
 stralloc tofrom = {0};
 stralloc text = {0};
@@ -63,7 +75,11 @@ void main()
  if (!(user = env_get("USER"))) _exit(0);
  if (!(sender = env_get("SENDER"))) _exit(0);
  if (!(userext = env_get("LOCAL"))) _exit(0);
+#ifdef HASUTMPX
+ if (str_len(user) > sizeof(ut->ut_user)) _exit(0);
+#else
  if (str_len(user) > sizeof(ut.ut_name)) _exit(0);
+#endif
 
  if (!stralloc_copys(&tofrom,"*** TO <")) _exit(0);
  if (!stralloc_cats(&tofrom,userext)) _exit(0);
@@ -88,6 +104,7 @@ void main()
  if (!stralloc_cat(&woof,&text)) _exit(0);
  if (!stralloc_cats(&woof,"\015\n")) _exit(0);
 
+#ifndef HASUTMPX
  fdutmp = open_read(UTMP_FILE);
  if (fdutmp == -1) _exit(0);
  substdio_fdbuf(&ssutmp,read,fdutmp,bufutmp,sizeof(bufutmp));
@@ -97,6 +114,13 @@ void main()
     {
      byte_copy(line,sizeof(ut.ut_line),ut.ut_line);
      line[sizeof(ut.ut_line)] = 0;
+#else
+ while ((ut = getutxent()))
+   if (ut->ut_type == USER_PROCESS && !str_diffn(ut->ut_user,user,sizeof(ut->ut_user)))
+    {
+     byte_copy(line,sizeof(ut->ut_line),ut->ut_line);
+     line[sizeof(ut->ut_line)] = 0;
+#endif
      if (line[0] == '/') continue;
      if (!line[0]) continue;
      if (line[str_chr(line,'.')]) continue;

--- a/tryutmpx.c
+++ b/tryutmpx.c
@@ -1,0 +1,6 @@
+#include <utmpx.h>
+
+void main()
+{
+  ;
+}


### PR DESCRIPTION
FreeBSD removed <utmp.h> almost a decade ago, leaving only <utmpx.h>:
https://github.com/freebsd/freebsd/commit/cb38fdae7c004eec078edf577e1819ce9760aecb

This is my qbiff-utmpx patch from <https://schmonz.com/qmail/qbiffutmpx/>.
With it, on a system...

- with <utmpx.h> but no <utmp.h>: build proceeds past qbiff.c

- with <utmpx.h> and <utmp.h>: build chooses <utmpx.h>

- with no <utmpx.h>: no change in behavior

Supports goals: being easily packaged by OS integrators
Broaches non-goals: none known
Risks: may run qbiff incorrectly on a system with broken utmpx implementation