### PR TITLE
symlink TARGETS to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+TARGETS

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ SHELL=/bin/sh
 
 default: it
 
+.PHONY: check clean default it man
+
 addresses.0: \
 addresses.5
 	nroff -man addresses.5 > addresses.0

--- a/TARGETS
+++ b/TARGETS
@@ -320,7 +320,6 @@ binm2
 binm2+df
 binm3
 binm3+df
-it
 qmail-local.0
 qmail-lspawn.0
 qmail-getpw.8
@@ -382,7 +381,5 @@ mbox.0
 addresses.0
 envelopes.0
 forgeries.0
-man
 setup
-check
 qtmp.h


### PR DESCRIPTION
This is an alternative to PR #13, which uses a symlink instead of copying the file.