### PR TITLE
add qtmp.h to SYSDEPS.

### DIFF
--- a/SYSDEPS
+++ b/SYSDEPS
@@ -12,6 +12,7 @@ hassgprm.h
 haswaitp.h
 hasmkffo.h
 uint32.h
+qtmp.h
 dns.lib
 socket.lib
 syslog.lib


### PR DESCRIPTION
This change was missed in the utmp.h/utmpx.h FreeBSD port.