### PR TITLE
remove incorrect usage of vfork()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
-20190805 version: notqmail 1.07.
+201908xx version: notqmail 1.07.
+20190819 remove incorrect usage of vfork()
 20190710 code: add instchown to set ownership and mode on installed files.
 20190709 code: add instpackage to install without root access.
 20190714 code: removed idedit, install-big. var-qmail packages are no more.

--- a/Makefile
+++ b/Makefile
@@ -632,13 +632,6 @@ forgeries.0: \
 forgeries.7
 	nroff -man forgeries.7 > forgeries.0
 
-fork.h: \
-compile load tryvfork.c fork.h1 fork.h2
-	( ( ./compile tryvfork.c && ./load tryvfork ) >/dev/null \
-	2>&1 \
-	&& cat fork.h2 || cat fork.h1 ) > fork.h
-	rm -f tryvfork.o tryvfork
-
 forward: \
 load forward.o qmail.o strerr.a alloc.a fd.a wait.a sig.a env.a \
 substdio.a error.a str.a fs.a auto_qmail.o

--- a/TARGETS
+++ b/TARGETS
@@ -5,7 +5,6 @@ systype
 load
 make-compile
 compile
-fork.h
 qmail-local.o
 qmail.o
 quote.o

--- a/fork.h
+++ b/fork.h
@@ -2,6 +2,5 @@
 #define FORK_H
 
 extern int fork();
-extern int vfork();
 
 #endif

--- a/fork.h1
+++ b/fork.h1
@@ -1,7 +1,0 @@
-#ifndef FORK_H
-#define FORK_H
-
-extern int fork();
-#define vfork fork
-
-#endif

--- a/qmail-lspawn.c
+++ b/qmail-lspawn.c
@@ -156,7 +156,7 @@ char *local;
  args[0] = "bin/qmail-getpw";
  args[1] = local;
  args[2] = 0;
- switch(gpwpid = vfork())
+ switch(gpwpid = fork())
   {
    case -1:
      _exit(QLX_SYS);

--- a/qmail-rspawn.c
+++ b/qmail-rspawn.c
@@ -96,7 +96,7 @@ char *s; char *r; int at;
  args[3] = r;
  args[4] = 0;
 
- if (!(f = vfork()))
+ if (!(f = fork()))
   {
    if (fd_move(0,fdmess) == -1) _exit(111);
    if (fd_move(1,fdout) == -1) _exit(111);

--- a/qmail.c
+++ b/qmail.c
@@ -29,7 +29,7 @@ struct qmail *qq;
   if (pipe(pim) == -1) return -1;
   if (pipe(pie) == -1) { close(pim[0]); close(pim[1]); return -1; }
  
-  switch(qq->pid = vfork()) {
+  switch(qq->pid = fork()) {
     case -1:
       close(pim[0]); close(pim[1]);
       close(pie[0]); close(pie[1]);

--- a/tryvfork.c
+++ b/tryvfork.c
@@ -1,4 +1,0 @@
-void main()
-{
-  vfork();
-}


### PR DESCRIPTION
From "man vfork(3)":

>   The vfork() function shall be equivalent to fork(), except that the behavior
>   is undefined if the process created by vfork() either modifies any data other
>   than a variable of type pid_t used to store the return value from vfork(), or
>   returns from the function in which vfork() was called, or calls any other
>   function before successfully calling _exit() or one of the exec family of
>   functions.

All of these instances do some filedescriptor modifications before calling execve(). Since these were the only users of vfork() the tryvfork detection can entirely go away.