### PR TITLE
CHANGES: add Mac OS X portability changes.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+20190711 portability problem: explicitly initialize strerr_sys and
+         define BIND_8_COMPAT to work around Mac OS X.
+20190709 doc: rename INSTALL, SENDMAIL to INSTALL.md, SENDMAIL.md to
+         support building on case-insensitive filesystems.
 20190715 code: detect and prefer utmpx where available.
 20190708 code: use DESTDIR environment variable as root directory in install.
 20071130 version: netqmail 1.06


### PR DESCRIPTION
This change was missed in PR #16.  @schmonz caught it doing pre-release due diligence.

It adds entries to CHANGES summarizing the work done making qmail build on Mac OS X.