### PR TITLE
Run alternate qmail-remote by setting QMAILREMOTE.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+20190826 code: if $QMAILREMOTE is set, it's invoked instead of qmail-remote.
 20190822 cleanup: remove unused dnsmxip.
 20190822 cleanup: remove unused dnscname.
 20190819 version: notqmail 1.07.

--- a/Makefile
+++ b/Makefile
@@ -1483,11 +1483,11 @@ tcpto.h readwrite.h timeoutconn.h timeoutread.h timeoutwrite.h
 
 qmail-rspawn: \
 load qmail-rspawn.o spawn.o tcpto_clean.o now.o coe.o sig.a open.a \
-seek.a lock.a wait.a fd.a stralloc.a alloc.a substdio.a error.a str.a \
+seek.a lock.a wait.a fd.a stralloc.a alloc.a substdio.a error.a env.a str.a \
 auto_qmail.o uid.o auto_userq.o auto_spawn.o
 	./load qmail-rspawn spawn.o tcpto_clean.o now.o coe.o \
 	sig.a open.a seek.a lock.a wait.a fd.a stralloc.a alloc.a \
-	auto_qmail.o uid.o auto_userq.o substdio.a error.a str.a \
+	auto_qmail.o uid.o auto_userq.o substdio.a error.a env.a str.a \
 	auto_spawn.o
 
 qmail-rspawn.0: \
@@ -1495,7 +1495,7 @@ qmail-rspawn.8
 	nroff -man qmail-rspawn.8 > qmail-rspawn.0
 
 qmail-rspawn.o: \
-compile qmail-rspawn.c fd.h wait.h substdio.h exit.h fork.h error.h \
+compile qmail-rspawn.c fd.h wait.h substdio.h exit.h fork.h error.h env.h \
 tcpto.h
 	./compile qmail-rspawn.c
 

--- a/qmail-remote.8
+++ b/qmail-remote.8
@@ -53,6 +53,13 @@ does not take options
 and does not follow the
 .B getopt
 standard.
+
+.B qmail-rspawn
+will invoke the contents of
+.B $QMAILREMOTE
+instead of
+.BR qmail-remote,
+if that environment variable is set.
 .SH TRANSPARENCY
 End-of-file in SMTP is encoded as dot CR LF.
 A dot at the beginning of a line is encoded as dot dot.

--- a/qmail-rspawn.8
+++ b/qmail-rspawn.8
@@ -16,6 +16,13 @@ invokes
 .B qmail-remote
 asynchronously,
 so the results may not be in the same order as the commands.
+
+.B qmail-rspawn
+will invoke the contents of
+.B $QMAILREMOTE
+instead of
+.BR qmail-remote,
+if that environment variable is set.
 .SH "SEE ALSO"
 qmail-send(8),
 qmail-remote(8)

--- a/qmail-rspawn.c
+++ b/qmail-rspawn.c
@@ -8,6 +8,7 @@
 #include "uidgid.h"
 #include "auto_uids.h"
 #include "auto_users.h"
+#include "env.h"
 
 int auto_uidq;
 
@@ -83,6 +84,16 @@ int len;
     }
 }
 
+static char *setup_qrargs()
+{
+ static char *qr;
+ if (qr) return qr;
+ qr = env_get("QMAILREMOTE");
+ if (qr) return qr;
+ qr = "qmail-remote";
+ return qr;
+}
+
 int spawn(fdmess,fdout,s,r,at)
 int fdmess; int fdout;
 char *s; char *r; int at;
@@ -90,7 +101,7 @@ char *s; char *r; int at;
  int f;
  char *(args[5]);
 
- args[0] = "qmail-remote";
+ args[0] = setup_qrargs();
  args[1] = r + at + 1;
  args[2] = s;
  args[3] = r;


### PR DESCRIPTION
This is like the QMAILQUEUE patch, but for qmail-remote(8).

With this change, on a system wherein qmail-start's environment...

- has QMAILREMOTE set: it's invoked by qmail-rspawn(8) instead of
  "qmail-remote"

- has QMAILREMOTE unset: no change in behavior

A QMAILREMOTE program must take care to adhere to the qmail-remote(8)
interface. It can wrap the original, concluding its work by running
qmail-remote, or it can be a full replacement.

Supports goals: "Adding interfaces and seams, where needed, to make extensions possible"
Broaches non-goals: none known
Risks: none known