### PR TITLE
Fix the non-compiling utmp case, found on OpenBSD.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 dist: xenial
 language: c
+env:
+  matrix:
+    - BUILD_NAME="default"
+    - BUILD_NAME="utmp" FORCE_UTMP="1"
 compiler:
  - gcc
  - clang
 script:
  - echo "${CC} -O2 -Wall" > conf-cc
- - make it man
- - env DESTDIR=/tmp/qmail make package
- - sudo make package
+ - if [ -n "${FORCE_UTMP}" ]; then export MAKEFLAGS="${MAKEFLAGS} -o qtmp.h"; cp qtmp.h1 qtmp.h; fi
+ - make ${MAKEFLAGS} it man
+ - env DESTDIR=/tmp/qmail make ${MAKEFLAGS} package
+ - sudo make ${MAKEFLAGS} package
  - sudo groupadd -g 200 nofiles
  - sudo groupadd -g 201 qmail
  - sudo useradd -u 200 -g 200 -d /var/qmail/alias alias
@@ -18,6 +23,6 @@ script:
  - sudo useradd -u 205 -g 201 -d /var/qmail qmailr
  - sudo useradd -u 206 -g 201 -d /var/qmail qmails
  - sudo ./instchown
- - sudo make check
+ - sudo make ${MAKEFLAGS} check
  - sudo rm -rf /var/qmail
- - sudo make setup check
+ - sudo make ${MAKEFLAGS} setup check

--- a/qtmp.h1
+++ b/qtmp.h1
@@ -11,12 +11,14 @@
 #endif
 #define UTMP_INIT \
     struct utmp utm; \
-    struct utmp *ut = &utm;
+    struct utmp *ut = &utm; \
     substdio ssutmp; \
-    char bufutmp[sizeof(struct utmp) * 16]
+    char bufutmp[sizeof(struct utmp) * 16]; \
+    int fdutmp
 #define UTMP_USER ut_name
 #define UTMP_OPEN \
-    if (open_read(UTMP_FILE) == -1) _exit(0); \
+    fdutmp = open_read(UTMP_FILE); \
+    if (fdutmp == -1) _exit(0); \
     substdio_fdbuf(&ssutmp,read,fdutmp,bufutmp,sizeof(bufutmp))
 #define UTMP_READ_MORE (substdio_get(&ssutmp,ut,sizeof(utm)) == sizeof(utm))
 #define UTMP_TYPE_MATCHES 1


### PR DESCRIPTION
By not having build-tested with utmp, I made two easy mistakes:

(1) In file included from qbiff.c:3:
    ./qtmp.h:15:5: error: unknown type name 'substdio'
        substdio ssutmp; \
        ^
    ./qtmp.h:16:43: error: expected ';' after top level declarator
        char bufutmp[sizeof(struct utmp) * 16]
                                              ^
                                              ;

Mistake: missed a trailing backslash on line 14.
Fix: add it.

(2) qbiff.c:81:2: error: use of undeclared identifier 'fdutmp'; did you mean 'ssutmp'?
     UTMP_OPEN;
     ^
    ./qtmp.h:20:33: note: expanded from macro 'UTMP_OPEN'
        substdio_fdbuf(&ssutmp,read,fdutmp,bufutmp,sizeof(bufutmp))

Mistake: tried to get rid of fdutmp by checking open_read() directly,
not realizing fdutmp was still needed on the next line (!).
Fix: bring back fdutmp.