### PR TITLE
remove register storage class declaration from codebase.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+20190822 code: remove register storage class declaration from codebase.
 20190826 code: if $QMAILREMOTE is set, it's invoked instead of qmail-remote.
 20190822 cleanup: remove unused dnsmxip.
 20190822 cleanup: remove unused dnscname.

--- a/byte_chr.c
+++ b/byte_chr.c
@@ -2,11 +2,11 @@
 
 unsigned int byte_chr(s,n,c)
 char *s;
-register unsigned int n;
+unsigned int n;
 int c;
 {
-  register char ch;
-  register char *t;
+  char ch;
+  char *t;
 
   ch = c;
   t = s;

--- a/byte_copy.c
+++ b/byte_copy.c
@@ -1,9 +1,9 @@
 #include "byte.h"
 
 void byte_copy(to,n,from)
-register char *to;
-register unsigned int n;
-register char *from;
+char *to;
+unsigned int n;
+char *from;
 {
   for (;;) {
     if (!n) return; *to++ = *from++; --n;

--- a/byte_cr.c
+++ b/byte_cr.c
@@ -1,9 +1,9 @@
 #include "byte.h"
 
 void byte_copyr(to,n,from)
-register char *to;
-register unsigned int n;
-register char *from;
+char *to;
+unsigned int n;
+char *from;
 {
   to += n;
   from += n;

--- a/byte_diff.c
+++ b/byte_diff.c
@@ -1,9 +1,9 @@
 #include "byte.h"
 
 int byte_diff(s,n,t)
-register char *s;
-register unsigned int n;
-register char *t;
+char *s;
+unsigned int n;
+char *t;
 {
   for (;;) {
     if (!n) return 0; if (*s != *t) break; ++s; ++t; --n;

--- a/byte_rchr.c
+++ b/byte_rchr.c
@@ -2,12 +2,12 @@
 
 unsigned int byte_rchr(s,n,c)
 char *s;
-register unsigned int n;
+unsigned int n;
 int c;
 {
-  register char ch;
-  register char *t;
-  register char *u;
+  char ch;
+  char *t;
+  char *u;
 
   ch = c;
   t = s;

--- a/byte_zero.c
+++ b/byte_zero.c
@@ -2,7 +2,7 @@
 
 void byte_zero(s,n)
 char *s;
-register unsigned int n;
+unsigned int n;
 {
   for (;;) {
     if (!n) break; *s++ = 0; --n;

--- a/case_diffb.c
+++ b/case_diffb.c
@@ -1,12 +1,12 @@
 #include "case.h"
 
 int case_diffb(s,len,t)
-register char *s;
+char *s;
 unsigned int len;
-register char *t;
+char *t;
 {
-  register unsigned char x;
-  register unsigned char y;
+  unsigned char x;
+  unsigned char y;
 
   while (len > 0) {
     --len;

--- a/case_diffs.c
+++ b/case_diffs.c
@@ -1,11 +1,11 @@
 #include "case.h"
 
 int case_diffs(s,t)
-register char *s;
-register char *t;
+char *s;
+char *t;
 {
-  register unsigned char x;
-  register unsigned char y;
+  unsigned char x;
+  unsigned char y;
 
   for (;;) {
     x = *s++ - 'A';

--- a/case_starts.c
+++ b/case_starts.c
@@ -1,11 +1,11 @@
 #include "case.h"
 
 int case_starts(s,t)
-register char *s;
-register char *t;
+char *s;
+char *t;
 {
-  register unsigned char x;
-  register unsigned char y;
+  unsigned char x;
+  unsigned char y;
 
   for (;;) {
     x = *s++ - 'A';

--- a/fmt_str.c
+++ b/fmt_str.c
@@ -1,9 +1,9 @@
 #include "fmt.h"
 
 unsigned int fmt_str(s,t)
-register char *s; register char *t;
+char *s; char *t;
 {
-  register unsigned int len;
+  unsigned int len;
   char ch;
   len = 0;
   if (s) { while (ch = t[len]) s[len++] = ch; }

--- a/fmt_strn.c
+++ b/fmt_strn.c
@@ -1,9 +1,9 @@
 #include "fmt.h"
 
 unsigned int fmt_strn(s,t,n)
-register char *s; register char *t; register unsigned int n;
+char *s; char *t; unsigned int n;
 {
-  register unsigned int len;
+  unsigned int len;
   char ch;
   len = 0;
   if (s) { while (n-- && (ch = t[len])) s[len++] = ch; }

--- a/fmt_uint.c
+++ b/fmt_uint.c
@@ -1,6 +1,6 @@
 #include "fmt.h"
 
-unsigned int fmt_uint(s,u) register char *s; register unsigned int u;
+unsigned int fmt_uint(s,u) char *s; unsigned int u;
 {
-  register unsigned long l; l = u; return fmt_ulong(s,l);
+  unsigned long l; l = u; return fmt_ulong(s,l);
 }

--- a/fmt_ulong.c
+++ b/fmt_ulong.c
@@ -1,8 +1,8 @@
 #include "fmt.h"
 
-unsigned int fmt_ulong(s,u) register char *s; register unsigned long u;
+unsigned int fmt_ulong(s,u) char *s; unsigned long u;
 {
-  register unsigned int len; register unsigned long q;
+  unsigned int len; unsigned long q;
   len = 1; q = u;
   while (q > 9) { ++len; q /= 10; }
   if (s) {

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -2,8 +2,8 @@
 #define GEN_ALLOC_DEFS_H
 
 #define GEN_ALLOC_ready(ta,type,field,len,a,i,n,x,base,ta_ready) \
-int ta_ready(x,n) register ta *x; register unsigned int n; \
-{ register unsigned int i; \
+int ta_ready(x,n) ta *x; unsigned int n; \
+{ unsigned int i; \
   if (x->field) { \
     i = x->a; \
     if (n > i) { \
@@ -15,8 +15,8 @@ int ta_ready(x,n) register ta *x; register unsigned int n; \
   return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); }
 
 #define GEN_ALLOC_readyplus(ta,type,field,len,a,i,n,x,base,ta_rplus) \
-int ta_rplus(x,n) register ta *x; register unsigned int n; \
-{ register unsigned int i; \
+int ta_rplus(x,n) ta *x; unsigned int n; \
+{ unsigned int i; \
   if (x->field) { \
     i = x->a; n += x->len; \
     if (n > i) { \
@@ -28,7 +28,7 @@ int ta_rplus(x,n) register ta *x; register unsigned int n; \
   return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); }
 
 #define GEN_ALLOC_append(ta,type,field,len,a,i,n,x,base,ta_rplus,ta_append) \
-int ta_append(x,i) register ta *x; register type *i; \
+int ta_append(x,i) ta *x; type *i; \
 { if (!ta_rplus(x,1)) return 0; x->field[x->len++] = *i; return 1; }
 
 #endif

--- a/getln.c
+++ b/getln.c
@@ -4,8 +4,8 @@
 #include "getln.h"
 
 int getln(ss,sa,match,sep)
-register substdio *ss;
-register stralloc *sa;
+substdio *ss;
+stralloc *sa;
 int *match;
 int sep;
 {

--- a/getln2.c
+++ b/getln2.c
@@ -4,14 +4,14 @@
 #include "getln.h"
 
 int getln2(ss,sa,cont,clen,sep)
-register substdio *ss;
-register stralloc *sa;
+substdio *ss;
+stralloc *sa;
 /*@out@*/char **cont;
 /*@out@*/unsigned int *clen;
 int sep;
 {
-  register char *x;
-  register unsigned int i;
+  char *x;
+  unsigned int i;
   int n;
  
   if (!stralloc_ready(sa,0)) return -1;

--- a/scan_8long.c
+++ b/scan_8long.c
@@ -1,9 +1,9 @@
 #include "scan.h"
 
-unsigned int scan_8long(s,u) register char *s; register unsigned long *u;
+unsigned int scan_8long(s,u) char *s; unsigned long *u;
 {
-  register unsigned int pos; register unsigned long result;
-  register unsigned long c;
+  unsigned int pos; unsigned long result;
+  unsigned long c;
   pos = 0; result = 0;
   while ((c = (unsigned long) (unsigned char) (s[pos] - '0')) < 8)
     { result = result * 8 + c; ++pos; }

--- a/scan_ulong.c
+++ b/scan_ulong.c
@@ -1,9 +1,9 @@
 #include "scan.h"
 
-unsigned int scan_ulong(s,u) register char *s; register unsigned long *u;
+unsigned int scan_ulong(s,u) char *s; unsigned long *u;
 {
-  register unsigned int pos; register unsigned long result;
-  register unsigned long c;
+  unsigned int pos; unsigned long result;
+  unsigned long c;
   pos = 0; result = 0;
   while ((c = (unsigned long) (unsigned char) (s[pos] - '0')) < 10)
     { result = result * 10 + c; ++pos; }

--- a/str_chr.c
+++ b/str_chr.c
@@ -1,11 +1,11 @@
 #include "str.h"
 
 unsigned int str_chr(s,c)
-register char *s;
+char *s;
 int c;
 {
-  register char ch;
-  register char *t;
+  char ch;
+  char *t;
 
   ch = c;
   t = s;

--- a/str_cpy.c
+++ b/str_cpy.c
@@ -1,10 +1,10 @@
 #include "str.h"
 
 unsigned int str_copy(s,t)
-register char *s;
-register char *t;
+char *s;
+char *t;
 {
-  register int len;
+  int len;
 
   len = 0;
   for (;;) {

--- a/str_diff.c
+++ b/str_diff.c
@@ -1,10 +1,10 @@
 #include "str.h"
 
 int str_diff(s,t)
-register char *s;
-register char *t;
+char *s;
+char *t;
 {
-  register char x;
+  char x;
 
   for (;;) {
     x = *s; if (x != *t) break; if (!x) break; ++s; ++t;

--- a/str_diffn.c
+++ b/str_diffn.c
@@ -1,11 +1,11 @@
 #include "str.h"
 
 int str_diffn(s,t,len)
-register char *s;
-register char *t;
+char *s;
+char *t;
 unsigned int len;
 {
-  register char x;
+  char x;
 
   for (;;) {
     if (!len--) return 0; x = *s; if (x != *t) break; if (!x) break; ++s; ++t;

--- a/str_len.c
+++ b/str_len.c
@@ -1,9 +1,9 @@
 #include "str.h"
 
 unsigned int str_len(s)
-register char *s;
+char *s;
 {
-  register char *t;
+  char *t;
 
   t = s;
   for (;;) {

--- a/str_rchr.c
+++ b/str_rchr.c
@@ -1,12 +1,12 @@
 #include "str.h"
 
 unsigned int str_rchr(s,c)
-register char *s;
+char *s;
 int c;
 {
-  register char ch;
-  register char *t;
-  register char *u;
+  char ch;
+  char *t;
+  char *u;
 
   ch = c;
   t = s;

--- a/str_start.c
+++ b/str_start.c
@@ -1,10 +1,10 @@
 #include "str.h"
 
 int str_start(s,t)
-register char *s;
-register char *t;
+char *s;
+char *t;
 {
-  register char x;
+  char x;
 
   for (;;) {
     x = *t++; if (!x) return 1; if (x != *s++) return 0;

--- a/substdi.c
+++ b/substdi.c
@@ -3,12 +3,12 @@
 #include "error.h"
 
 static int oneread(op,fd,buf,len)
-register int (*op)();
-register int fd;
-register char *buf;
-register int len;
+int (*op)();
+int fd;
+char *buf;
+int len;
 {
-  register int r;
+  int r;
 
   for (;;) {
     r = op(fd,buf,len);
@@ -18,12 +18,12 @@ register int len;
 }
 
 static int getthis(s,buf,len)
-register substdio *s;
-register char *buf;
-register int len;
+substdio *s;
+char *buf;
+int len;
 {
-  register int r;
-  register int q;
+  int r;
+  int q;
  
   r = s->p;
   q = r - len;
@@ -34,10 +34,10 @@ register int len;
 }
 
 int substdio_feed(s)
-register substdio *s;
+substdio *s;
 {
-  register int r;
-  register int q;
+  int r;
+  int q;
 
   if (s->p) return s->p;
   q = s->n;
@@ -51,11 +51,11 @@ register substdio *s;
 }
 
 int substdio_bget(s,buf,len)
-register substdio *s;
-register char *buf;
-register int len;
+substdio *s;
+char *buf;
+int len;
 {
-  register int r;
+  int r;
  
   if (s->p > 0) return getthis(s,buf,len);
   r = s->n; if (r <= len) return oneread(s->op,s->fd,buf,r);
@@ -64,11 +64,11 @@ register int len;
 }
 
 int substdio_get(s,buf,len)
-register substdio *s;
-register char *buf;
-register int len;
+substdio *s;
+char *buf;
+int len;
 {
-  register int r;
+  int r;
  
   if (s->p > 0) return getthis(s,buf,len);
   if (s->n <= len) return oneread(s->op,s->fd,buf,len);
@@ -77,14 +77,14 @@ register int len;
 }
 
 char *substdio_peek(s)
-register substdio *s;
+substdio *s;
 {
   return s->x + s->n;
 }
 
 void substdio_seek(s,len)
-register substdio *s;
-register int len;
+substdio *s;
+int len;
 {
   s->n += len;
   s->p -= len;

--- a/substdio.c
+++ b/substdio.c
@@ -1,11 +1,11 @@
 #include "substdio.h"
 
 void substdio_fdbuf(s,op,fd,buf,len)
-register substdio *s;
-register int (*op)();
-register int fd;
-register char *buf;
-register int len;
+substdio *s;
+int (*op)();
+int fd;
+char *buf;
+int len;
 {
   s->x = buf;
   s->fd = fd;

--- a/substdio_copy.c
+++ b/substdio_copy.c
@@ -1,11 +1,11 @@
 #include "substdio.h"
 
 int substdio_copy(ssout,ssin)
-register substdio *ssout;
-register substdio *ssin;
+substdio *ssout;
+substdio *ssin;
 {
-  register int n;
-  register char *x;
+  int n;
+  char *x;
 
   for (;;) {
     n = substdio_feed(ssin);

--- a/substdo.c
+++ b/substdo.c
@@ -4,12 +4,12 @@
 #include "error.h"
 
 static int allwrite(op,fd,buf,len)
-register int (*op)();
-register int fd;
-register char *buf;
-register int len;
+int (*op)();
+int fd;
+char *buf;
+int len;
 {
-  register int w;
+  int w;
 
   while (len) {
     w = op(fd,buf,len);
@@ -25,9 +25,9 @@ register int len;
 }
 
 int substdio_flush(s)
-register substdio *s;
+substdio *s;
 {
-  register int p;
+  int p;
  
   p = s->p;
   if (!p) return 0;
@@ -36,11 +36,11 @@ register substdio *s;
 }
 
 int substdio_bput(s,buf,len)
-register substdio *s;
-register char *buf;
-register int len;
+substdio *s;
+char *buf;
+int len;
 {
-  register int n;
+  int n;
  
   while (len > (n = s->n - s->p)) {
     byte_copy(s->x + s->p,n,buf); s->p += n; buf += n; len -= n;
@@ -53,11 +53,11 @@ register int len;
 }
 
 int substdio_put(s,buf,len)
-register substdio *s;
-register char *buf;
-register int len;
+substdio *s;
+char *buf;
+int len;
 {
-  register int n;
+  int n;
  
   n = s->n;
   if (len > n - s->p) {
@@ -78,31 +78,31 @@ register int len;
 }
 
 int substdio_putflush(s,buf,len)
-register substdio *s;
-register char *buf;
-register int len;
+substdio *s;
+char *buf;
+int len;
 {
   if (substdio_flush(s) == -1) return -1;
   return allwrite(s->op,s->fd,buf,len);
 }
 
 int substdio_bputs(s,buf)
-register substdio *s;
-register char *buf;
+substdio *s;
+char *buf;
 {
   return substdio_bput(s,buf,str_len(buf));
 }
 
 int substdio_puts(s,buf)
-register substdio *s;
-register char *buf;
+substdio *s;
+char *buf;
 {
   return substdio_put(s,buf,str_len(buf));
 }
 
 int substdio_putsflush(s,buf)
-register substdio *s;
-register char *buf;
+substdio *s;
+char *buf;
 {
   return substdio_putflush(s,buf,str_len(buf));
 }


### PR DESCRIPTION
The register keyword is a storage class declaration, like extern or
static.  It is a hint to the compiler that the variable will be
heavily used and can exist only in a hardware register, permitting it
to have no memory location.

Let the compiler make that decision.