### PR TITLE
include unistd.h in exit.h to declare _exit.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1304,7 +1304,7 @@ qmail-pw2u.9 conf-qmail conf-break conf-spawn
 qmail-pw2u.o: \
 compile qmail-pw2u.c substdio.h readwrite.h subfd.h substdio.h \
 sgetopt.h subgetopt.h control.h constmap.h stralloc.h gen_alloc.h \
-fmt.h str.h scan.h open.h error.h getln.h auto_break.h auto_qmail.h \
+fmt.h str.h scan.h open.h error.h getln.h exit.h auto_break.h auto_qmail.h \
 auto_users.h byte.h
 	./compile qmail-pw2u.c
 
@@ -1357,7 +1357,7 @@ qmail-qmtpd.8
 qmail-qmtpd.o: \
 compile qmail-qmtpd.c stralloc.h gen_alloc.h substdio.h qmail.h \
 substdio.h now.h datetime.h str.h fmt.h env.h sig.h rcpthosts.h \
-auto_qmail.h readwrite.h control.h received.h
+auto_qmail.h readwrite.h control.h received.h exit.h
 	./compile qmail-qmtpd.c
 
 qmail-qread: \

--- a/Makefile
+++ b/Makefile
@@ -602,7 +602,7 @@ forward.0: \
 forward.1
 
 forward.o: \
-compile forward.c sig.h readwrite.h exit.h env.h qmail.h substdio.h \
+compile forward.c sig.h readwrite.h env.h qmail.h substdio.h \
 strerr.h substdio.h fmt.h
 	./compile forward.c
 
@@ -876,7 +876,7 @@ maildirwatch.1
 
 maildirwatch.o: \
 compile maildirwatch.c getln.h substdio.h subfd.h substdio.h prioq.h \
-datetime.h gen_alloc.h stralloc.h gen_alloc.h str.h exit.h hfield.h \
+datetime.h gen_alloc.h stralloc.h gen_alloc.h str.h hfield.h \
 readwrite.h open.h headerbody.h maildir.h strerr.h
 	./compile maildirwatch.c
 

--- a/exit.h
+++ b/exit.h
@@ -1,6 +1,6 @@
 #ifndef EXIT_H
 #define EXIT_H
 
-extern void _exit();
+#include <unistd.h>
 
 #endif

--- a/forward.c
+++ b/forward.c
@@ -1,6 +1,5 @@
 #include "sig.h"
 #include "readwrite.h"
-#include "exit.h"
 #include "env.h"
 #include "qmail.h"
 #include "strerr.h"

--- a/maildirwatch.c
+++ b/maildirwatch.c
@@ -4,7 +4,6 @@
 #include "prioq.h"
 #include "stralloc.h"
 #include "str.h"
-#include "exit.h"
 #include "hfield.h"
 #include "readwrite.h"
 #include "open.h"

--- a/qmail-pw2u.c
+++ b/qmail-pw2u.c
@@ -14,6 +14,7 @@
 #include "open.h"
 #include "error.h"
 #include "getln.h"
+#include "exit.h"
 #include "auto_break.h"
 #include "auto_qmail.h"
 #include "auto_users.h"

--- a/qmail-qmtpd.c
+++ b/qmail-qmtpd.c
@@ -12,6 +12,7 @@
 #include "readwrite.h"
 #include "control.h"
 #include "received.h"
+#include "exit.h"
 
 void badproto() { _exit(100); }
 void resources() { _exit(111); }


### PR DESCRIPTION
_exit(2) is declared in unistd.h.  Instead of redeclaring it in exit.h, include that system header to get the correct function signature.

As a separate commit, also remove exit.h from forward.c andt maildirwatch.c.  Neither of these programs calls exit directly, and so do not need the exit.h header.

This is the 1.08 portion of the _exit declaration cleanup.  The 1.9 portion of this series is PR #44 .  It depends on PR #80 and so has cherry-picked the single commit from that series.

This change is necessary for -Wall -Werror, to prevent the following kind of error:

qmail-pw2u.c: In function ‘die_read’:
qmail-pw2u.c:34:3: error: incompatible implicit declaration of built-in function ‘_exit’ [-Werror]
   _exit(111);
   ^~~~~

Which cannot be turned off without also turning off -Werror.