### PR TITLE
include unistd.h in readwrite.h to declare read, write.

### DIFF
--- a/readwrite.h
+++ b/readwrite.h
@@ -1,7 +1,6 @@
 #ifndef READWRITE_H
 #define READWRITE_H
 
-extern int read();
-extern int write();
+#include <unistd.h>
 
 #endif


### PR DESCRIPTION
read(2) and write(2) are declared in unistd.h.  Instead of redeclaring them in readwrite.h, include that system header to get the correct function signature.

This is the 1.08 portion of the read, write declaration cleanup.  The 1.9 portion of this series is PR #43.

This change is necessary for -Wall -Werror, to prevent the following:

./compile qmail-local.c
In file included from exit.h:4:0,
                 from qmail-local.c:7:
/usr/include/unistd.h:363:16: error: conflicting types for ‘read’
 extern ssize_t read (int __fd, void *__buf, size_t __nbytes) __wur;
                ^~~~
In file included from qmail-local.c:3:0:
readwrite.h:4:12: note: previous declaration of ‘read’ was here
 extern int read();
            ^~~~

Which happens as a side-effect of PR #79, where we include unistd.h everywhere we include exit.h.