### PR TITLE
include stdlib.h and stop redeclaring malloc, free in alloc.c

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -1,7 +1,6 @@
+#include <stdlib.h>
 #include "alloc.h"
 #include "error.h"
-extern char *malloc();
-extern void free();
 
 #define ALIGNMENT 16 /* XXX: assuming that this alignment is enough */
 #define SPACE 4096 /* must be multiple of ALIGNMENT */


### PR DESCRIPTION
This change is necessary for -Wall -Werror, to prevent the following:

./compile alloc.c
alloc.c:3:14: error: conflicting types for built-in function ‘malloc’ [-Werror]
 extern char *malloc();
              ^~~~~~

Which cannot be turned off without also turning off -Werror.