### PR TITLE
Fix leap second handling on systems running TAI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,14 @@ byte_zero.o: \
 compile byte_zero.c byte.h
 	./compile byte_zero.c
 
+caldate_fmjd.o: \
+compile caldate_fmjd.c caldate.h
+	./compile caldate_fmjd.c
+
+caltime_utc.o: \
+compile caltime_utc.c caltime.h
+	./compile caltime_utc.c
+
 case.a: \
 makelib case_diffb.o case_diffs.o case_lowerb.o case_lowers.o \
 case_starts.o
@@ -411,11 +419,13 @@ warn-auto.sh datemail.sh conf-qmail conf-break conf-split
 	chmod 755 datemail
 
 datetime.a: \
-makelib datetime.o datetime_un.o
-	./makelib datetime.a datetime.o datetime_un.o
+makelib datetime.o datetime_un.o caltime_utc.o caldate_fmjd.o leapsecs_sub.o \
+leapsecs_init.o tai_unpack.o
+	./makelib datetime.a datetime.o datetime_un.o caltime_utc.o \
+	caldate_fmjd.o leapsecs_sub.o leapsecs_init.o tai_unpack.o
 
 datetime.o: \
-compile datetime.c datetime.h
+compile datetime.c datetime.h caltime.h tai.h
 	./compile datetime.c
 
 datetime_un.o: \
@@ -777,6 +787,14 @@ forward preline condredirect bouncesaying except maildirmake \
 maildir2mbox install instpackage instchown \
 instcheck home home+df proc proc+df binm1 binm1+df binm2 binm2+df \
 binm3 binm3+df
+
+leapsecs_init.o: \
+compile leapsecs_init.c leapsecs.h
+	./compile leapsecs_init.c
+
+leapsecs_sub.o: \
+compile leapsecs_sub.c leapsecs.h
+	./compile leapsecs_sub.c
 
 load: \
 make-load warn-auto.sh
@@ -1268,10 +1286,10 @@ timeoutread.h timeoutwrite.h auto_qmail.h control.h fmt.h
 
 qmail-qmqpd: \
 load qmail-qmqpd.o received.o date822fmt.o qmail.o auto_qmail.o \
-env.a substdio.a sig.a error.a wait.a fd.a str.a datetime.a fs.a
+env.a substdio.a sig.a error.a wait.a fd.a str.a datetime.a fs.a open.a
 	./load qmail-qmqpd received.o date822fmt.o qmail.o \
 	auto_qmail.o env.a substdio.a sig.a error.a wait.a fd.a \
-	str.a datetime.a fs.a 
+	str.a datetime.a fs.a open.a
 
 qmail-qmqpd.0: \
 qmail-qmqpd.8
@@ -1842,6 +1860,10 @@ trysyslog.c compile load
 	./load trysyslog -lgen ) >/dev/null 2>&1 \
 	&& echo -lgen || exit 0 ) > syslog.lib
 	rm -f trysyslog.o trysyslog
+
+tai_unpack.o: \
+compile tai_unpack.c tai.h
+	./compile tai_unpack.c
 
 tcp-env: \
 load tcp-env.o dns.o remoteinfo.o timeoutread.o timeoutwrite.o \

--- a/TARGETS
+++ b/TARGETS
@@ -371,3 +371,8 @@ forgeries.0
 setup
 qtmp.h
 qmail-send.service
+caldate_fmjd.o
+caltime_utc.o
+leapsecs_init.o
+leapsecs_sub.o
+tai_unpack.o

--- a/caldate.h
+++ b/caldate.h
@@ -1,0 +1,19 @@
+#ifndef CALDATE_H
+#define CALDATE_H
+
+struct caldate {
+  long year;
+  int month;
+  int day;
+} ;
+
+extern unsigned int caldate_fmt(char *, const struct caldate *);
+extern unsigned int caldate_scan(const char *, struct caldate *);
+
+extern void caldate_frommjd(struct caldate *, long, int *, int *);
+extern long caldate_mjd(const struct caldate *);
+extern void caldate_normalize(struct caldate *);
+
+extern void caldate_easter(struct caldate *);
+
+#endif

--- a/caldate_fmjd.c
+++ b/caldate_fmjd.c
@@ -1,0 +1,44 @@
+#include "caldate.h"
+
+void caldate_frommjd(struct caldate *cd, long day, int *pwday, int *pyday)
+{
+  long year;
+  long month;
+  int yday;
+
+  year = day / 146097L;
+  day %= 146097L;
+  day += 678881L;
+  while (day >= 146097L) { day -= 146097L; ++year; }
+
+  /* year * 146097 + day - 678881 is MJD; 0 <= day < 146097 */
+  /* 2000-03-01, MJD 51604, is year 5, day 0 */
+
+  if (pwday) *pwday = (day + 3) % 7;
+
+  year *= 4;
+  if (day == 146096L) { year += 3; day = 36524L; }
+  else { year += day / 36524L; day %= 36524L; }
+  year *= 25;
+  year += day / 1461;
+  day %= 1461;
+  year *= 4;
+
+  yday = (day < 306);
+  if (day == 1460) { year += 3; day = 365; }
+  else { year += day / 365; day %= 365; }
+  yday += day;
+
+  day *= 10;
+  month = (day + 5) / 306;
+  day = (day + 5) % 306;
+  day /= 10;
+  if (month >= 10) { yday -= 306; ++year; month -= 10; }
+  else { yday += 59; month += 2; }
+
+  cd->year = year;
+  cd->month = month + 1;
+  cd->day = day + 1;
+
+  if (pyday) *pyday = yday;
+}

--- a/caltime.h
+++ b/caltime.h
@@ -1,0 +1,20 @@
+#ifndef CALTIME_H
+#define CALTIME_H
+
+#include "caldate.h"
+
+struct caltime {
+  struct caldate date;
+  int hour;
+  int minute;
+  int second;
+  long offset;
+} ;
+
+extern void caltime_tai(const struct caltime *, struct tai *);
+extern void caltime_utc(struct caltime *, const struct tai *, int *, int *);
+
+extern unsigned int caltime_fmt(char *, const struct caltime *);
+extern unsigned int caltime_scan(const char *, struct caltime *);
+
+#endif

--- a/caltime_utc.c
+++ b/caltime_utc.c
@@ -1,0 +1,31 @@
+#include "tai.h"
+#include "leapsecs.h"
+#include "caldate.h"
+#include "caltime.h"
+
+/* XXX: breaks tai encapsulation */
+
+void caltime_utc(struct caltime *ct, const struct tai *t, int *pwday, int *pyday)
+{
+  struct tai t2 = *t;
+  uint64_t u;
+  int leap;
+  long s;
+
+  /* XXX: check for overflow? */
+
+  leap = leapsecs_sub(&t2);
+  u = t2.x;
+
+  u += 58486;
+  s = u % 86400ULL;
+
+  ct->second = (s % 60) + leap; s /= 60;
+  ct->minute = s % 60; s /= 60;
+  ct->hour = s;
+
+  u /= 86400ULL;
+  caldate_frommjd(&ct->date,/*XXX*/(long) (u - 53375995543064ULL),pwday,pyday);
+
+  ct->offset = 0;
+}

--- a/datetime.c
+++ b/datetime.c
@@ -1,55 +1,25 @@
 /* 19950925 */
+#include "caltime.h"
 #include "datetime.h"
+#include "tai.h"
 
-void datetime_tai(dt,t)
-struct datetime *dt;
-datetime_sec t;
+void datetime_tai(struct datetime *dt, datetime_sec t)
 {
-  int day;
-  int tod;
-  int year;
   int yday;
   int wday;
-  int mon;
+
+  struct tai t2;
+  struct caltime ct;
+
+  tai_unix(&t2,t);
+  caltime_utc(&ct,&t2,&wday,&yday);
  
-  tod = t % 86400;
-  day = t / 86400;
-  if (tod < 0) { tod += 86400; --day; }
- 
-  dt->hour = tod / 3600;
-  tod %= 3600;
-  dt->min = tod / 60;
-  dt->sec = tod % 60;
- 
-  wday = (day + 4) % 7; if (wday < 0) wday += 7;
+  dt->hour = ct.hour;
+  dt->min = ct.minute;
+  dt->sec = ct.second;
   dt->wday = wday;
- 
-  day -= 11017;
-  /* day 0 is march 1, 2000 */
-  year = 5 + day / 146097;
-  day = day % 146097; if (day < 0) { day += 146097; --year; }
-  /* from now on, day is nonnegative */
-  year *= 4;
-  if (day == 146096) { year += 3; day = 36524; }
-  else { year += day / 36524; day %= 36524; }
-  year *= 25;
-  year += day / 1461;
-  day %= 1461;
-  year *= 4;
-  yday = (day < 306);
-  if (day == 1460) { year += 3; day = 365; }
-  else { year += day / 365; day %= 365; }
-  yday += day;
- 
-  day *= 10;
-  mon = (day + 5) / 306;
-  day = day + 5 - 306 * mon;
-  day /= 10;
-  if (mon >= 10) { yday -= 306; ++year; mon -= 10; }
-  else { yday += 59; mon += 2; }
- 
   dt->yday = yday;
-  dt->year = year - 1900;
-  dt->mon = mon;
-  dt->mday = day + 1;
+  dt->year = ct.date.year - 1900;
+  dt->mon = ct.date.month - 1;
+  dt->mday = ct.date.day;
 }

--- a/leapsecs.h
+++ b/leapsecs.h
@@ -1,0 +1,10 @@
+#ifndef LEAPSECS_H
+#define LEAPSECS_H
+
+#include "tai.h"
+
+extern int leapsecs_init();
+
+extern int leapsecs_sub(struct tai *);
+
+#endif

--- a/leapsecs_init.c
+++ b/leapsecs_init.c
@@ -1,0 +1,68 @@
+#include "leapsecs.h"
+
+#include "open.h"
+
+#include <sys/stat.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+struct tai *leapsecs = 0;
+int leapsecs_num = 0;
+
+static int leapsecs_read()
+{
+  int fd;
+  struct stat st;
+  struct tai *t;
+  int n;
+  int i;
+
+  fd = open_read("/etc/leapsecs.dat");
+  if (fd == -1) {
+    if (errno != ENOENT) return -1;
+    free(leapsecs);
+    leapsecs = NULL;
+    leapsecs_num = 0;
+    return 0;
+  }
+
+  if (fstat(fd,&st) == -1) {
+    close(fd);
+    return -1;
+  }
+
+  t = malloc(st.st_size);
+  if (!t) {
+    close(fd);
+    return -1;
+  }
+
+  n = read(fd,t,st.st_size);
+  close(fd);
+  if (n != st.st_size) { free(t); return -1; }
+
+  n /= sizeof(struct tai);
+
+  for (i = 0;i < n;++i) {
+    struct tai u;
+    tai_unpack((char *) &t[i],&u);
+    t[i] = u;
+  }
+
+  free(leapsecs);
+
+  leapsecs = t;
+  leapsecs_num = n;
+
+  return 0;
+}
+
+int leapsecs_init()
+{
+  static int flaginit;
+  if (flaginit) return 0;
+  if (leapsecs_read() == -1) return -1;
+  flaginit = 1;
+  return 0;
+}

--- a/leapsecs_sub.c
+++ b/leapsecs_sub.c
@@ -1,0 +1,27 @@
+#include "leapsecs.h"
+
+/* XXX: breaks tai encapsulation */
+
+extern struct tai *leapsecs;
+extern int leapsecs_num;
+
+int leapsecs_sub(struct tai *t)
+{
+  int i;
+  uint64_t u;
+  int s;
+
+  if (leapsecs_init() == -1) return 0;
+
+  u = t->x;
+  s = 0;
+
+  for (i = 0;i < leapsecs_num;++i) {
+    if (u < leapsecs[i].x) break;
+    ++s;
+    if (u == leapsecs[i].x) { t->x = u - s; return 1; }
+  }
+
+  t->x = u - s;
+  return 0;
+}

--- a/tai.h
+++ b/tai.h
@@ -1,0 +1,28 @@
+/* Public domain. */
+
+#ifndef TAI_H
+#define TAI_H
+
+#include <stdint.h>
+
+struct tai {
+  uint64_t x;
+} ;
+
+#define tai_unix(t,u) ((void) ((t)->x = 4611686018427387914ULL + (uint64_t) (u)))
+
+extern void tai_now(struct tai *);
+
+#define tai_approx(t) ((double) ((t)->x))
+
+extern void tai_add(struct tai *,const struct tai *,const struct tai *);
+extern void tai_sub(struct tai *,const struct tai *,const struct tai *);
+#define tai_less(t,u) ((t)->x < (u)->x)
+
+#define TAI_PACK 8
+extern void tai_pack(char *,const struct tai *);
+extern void tai_unpack(const char *,struct tai *);
+
+extern void tai_uint(struct tai *,unsigned int);
+
+#endif

--- a/tai_unpack.c
+++ b/tai_unpack.c
@@ -1,0 +1,16 @@
+/* Public domain. */
+
+#include "tai.h"
+
+void tai_unpack(const char *s,struct tai *t)
+{
+  uint64_t x;
+  int i;
+
+  x = (unsigned char) s[0];
+  for (i = 1; i < 8; i++) {
+    x <<= 8;
+    x += (unsigned char) s[i];
+  }
+  t->x = x;
+}


### PR DESCRIPTION
This patch is intended to fix a minor bug in qmail that uses incorrect
timestamp information on systems using a TAI system clock. Since the TAI
timescale does not permit leap seconds, it is offset from the more
common UTC timescale by an integer number of seconds. As of 2016-12-31,
when another leap second was added, TAI is exactly 37 seconds ahead of
UTC. The 37 seconds results from the initial difference of 10 seconds at
the start of 1972, plus 27 leap seconds in UTC since 1972.

Converting between TAI and UTC is easy if you have an accurate table of
all previous leap seconds, usually placed in "/etc/leapsecs.dat". qmail
does not check for "/etc/leapsecs.dat" and thus does not handle leap
seconds correctly on systems that use TAI without this patch.

Converting qmail's internals to use the libtai library everywhere would
involve rewriting all of its time-handling code. Instead, I chose to
simply scoop out the datetime() function and replace it with a few lines
of libtai's most useful features. This provides support for systems that
use TAI without seriously changing the way qmail understands time.

The file "datetime.c" now contains libtai's ability to convert from
seconds since the UNIX epoch to a caltime struct, using that value to
check "/etc/leapsecs.dat" for the correct TAI - UTC offset. This value
is then given to qmail to digest into its old datetime struct, the
precursor to libtai's caltime.