### PR TITLE
Improve Maildir file uniqueness in qmail-local.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -568,6 +568,10 @@ fmt_ulong.o: \
 compile fmt_ulong.c fmt.h
 	./compile fmt_ulong.c
 
+fmt_xlong.o: \
+compile fmt_xlong.c fmt.h
+	./compile fmt_xlong.c
+
 fmtqfn.o: \
 compile fmtqfn.c fmtqfn.h fmt.h auto_split.h
 	./compile fmtqfn.c
@@ -591,9 +595,9 @@ strerr.h substdio.h fmt.h
 
 fs.a: \
 makelib fmt_str.o fmt_strn.o fmt_uint.o fmt_uint0.o fmt_ulong.o \
-scan_ulong.o scan_8long.o
+fmt_xlong.o scan_ulong.o scan_8long.o
 	./makelib fs.a fmt_str.o fmt_strn.o fmt_uint.o fmt_uint0.o \
-	fmt_ulong.o scan_ulong.o scan_8long.o
+	fmt_ulong.o fmt_xlong.o scan_ulong.o scan_8long.o
 
 getln.a: \
 makelib getln.o getln2.o

--- a/TARGETS
+++ b/TARGETS
@@ -104,6 +104,7 @@ fmt_strn.o
 fmt_uint.o
 fmt_uint0.o
 fmt_ulong.o
+fmt_xlong.o
 scan_ulong.o
 scan_8long.o
 fs.a

--- a/fmt.h
+++ b/fmt.h
@@ -12,5 +12,6 @@ extern unsigned int fmt_ulong(char *, unsigned long);
 
 extern unsigned int fmt_str(char *, char *);
 extern unsigned int fmt_strn(char *, char *, unsigned int);
+extern unsigned int fmt_xlong(char *, unsigned long);
 
 #endif

--- a/fmt_xlong.c
+++ b/fmt_xlong.c
@@ -1,0 +1,17 @@
+#include "fmt.h"
+
+/* writes ulong u in hex to char *s, does not NULL-terminate */
+unsigned int fmt_xlong(char *s, unsigned long u)
+{
+ unsigned int len;
+ unsigned long q;
+ unsigned long c;
+ len = 1; q = u;
+ while (q > 15) { ++len; q /= 16; }
+ if (s)
+  {
+   s += len;
+   do { c = u & 15; *--s = (c > 9 ? 'a' - 10 : '0') + c; u /= 16; } while(u);
+  }
+ return len;
+}

--- a/qmail-local.c
+++ b/qmail-local.c
@@ -1,4 +1,5 @@
 #include <sys/types.h>
+#include <sys/time.h>
 #include <sys/stat.h>
 #include <stdlib.h>
 #include "readwrite.h"
@@ -65,6 +66,7 @@ stralloc ueo = {0};
 stralloc cmds = {0};
 stralloc messline = {0};
 stralloc foo = {0};
+stralloc hostname = {0};
 
 char buf[1024];
 char outbuf[1024];
@@ -80,7 +82,7 @@ void maildir_child(dir)
 char *dir;
 {
  unsigned long pid;
- unsigned long time;
+ struct timeval time;
  char myhost[64];
  char *s;
  int loop;
@@ -88,27 +90,47 @@ char *dir;
  int fd;
  substdio ss;
  substdio ssout;
+ stralloc hostsa = {0};
+ size_t hostnamemaxlen = 256;
 
  sig_alarmcatch(sigalrm);
  if (chdir(dir) == -1) { if (error_temp(errno)) _exit(1); _exit(2); }
- pid = getpid();
  myhost[0] = 0;
- gethostname(myhost,sizeof(myhost));
+ pid = getpid();
+ if (!stralloc_ready(&hostsa,hostnamemaxlen)) temp_nomem();
+ if (!gethostname(hostsa.s,hostnamemaxlen)) error_temp(errno);
+ hostsa.s[hostnamemaxlen-1] = 0;
+
+ s = hostsa.s;
+ for (loop = 0; loop < str_len(hostsa.s); ++loop)
+  {
+   if (hostsa.s[loop] == '/')
+    {
+     if (!stralloc_cats(&hostname,"\\057")) temp_nomem();
+     continue;
+    }
+   if (hostsa.s[loop] == ':')
+    {
+     if (!stralloc_cats(&hostname,"\\072")) temp_nomem();
+     continue;
+    }
+   if (!stralloc_append(&hostname,s+loop)) temp_nomem();
+  }
+
  for (loop = 0;;++loop)
   {
-   time = now();
+   gettimeofday(&time, NULL);
    s = fntmptph;
    s += fmt_str(s,"tmp/");
-   s += fmt_ulong(s,time); *s++ = '.';
-   s += fmt_ulong(s,pid); *s++ = '.';
-   s += fmt_strn(s,myhost,sizeof(myhost)); *s++ = 0;
+   s += fmt_ulong(s,time.tv_sec); *s++ = '.';
+   *s++ = 'M'; s += fmt_ulong(s,time.tv_usec);
+   *s++ = 'P'; s += fmt_ulong(s,pid); *s++ = '.';
+   s += fmt_strn(s,hostname.s,hostname.len); *s++ = 0;
    if (stat(fntmptph,&st) == -1) if (errno == error_noent) break;
    /* really should never get to this point */
    if (loop == 2) _exit(1);
    sleep(2);
   }
- str_copy(fnnewtph,fntmptph);
- byte_copy(fnnewtph,3,"new");
 
  alarm(86400);
  fd = open_excl(fntmptph);
@@ -126,8 +148,23 @@ char *dir;
   }
 
  if (substdio_flush(&ssout) == -1) goto fail;
+ if (fstat(fd, &st) == -1) goto fail;
  if (fsync(fd) == -1) goto fail;
  if (close(fd) == -1) goto fail; /* NFS dorks */
+
+ s = fnnewtph;
+ s += fmt_str(s,"new/");
+ s += fmt_ulong(s,time.tv_sec); *s++ = '.';
+
+ /* in hexadecimal */
+ *s++ = 'I'; s += fmt_xlong(s,st.st_ino);
+ *s++ = 'V'; s += fmt_xlong(s,st.st_dev);
+
+ /* in decimal */
+ *s++ = 'M'; s += fmt_ulong(s,time.tv_usec);
+ *s++ = 'P'; s += fmt_ulong(s,pid); *s++ = '.';
+
+ s += fmt_strn(s,hostname.s,hostname.len); *s++ = 0;
 
  if (link(fntmptph,fnnewtph) == -1) goto fail;
    /* if it was error_exist, almost certainly successful; i hate NFS */


### PR DESCRIPTION
Some operating systems quickly recycle PIDs, which can lead to
collisions between Maildir-style filenames, which must be unique and
non-repeatable within one second. This patch is just a means of updating
qmail-local to use the format of the revised Maildir protocol.

It uses four unique identifiers:
  * inode number of the file written to Maildir/tmp
  * device number of the file written to Maildir/tmp
  * time in microseconds
  * the PID of the writing process

A Maildir-style filename would look like the following:

In Maildir/tmp:
  time.MmicrosecondsPpid.host
In Maildir/new:
  time.IinodeVdeviceMmicrosecondsPpid.host

Additionally, this patch further comforms to the revised Maildir
protocol by looking through the hostname for instances of '/' and ':',
replacing them with "\057" and "\072", respectively, when writing it to
disk. Special thanks go to Matthias Andree for design & sanity-checking.