### PR TITLE
qmail-pop3d: exit 1, pronto, if running as root.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+20200514 bug: qmail-pop3d runs as root if root authenticates.
+         impact: vector for dictionary attack on root password.
+         fix: exit 1, same as a failed checkpassword login.
 20200514 code: changed qmail-popup interface (leave kid's fd 2 alone).
 20200511 code: remove tryshsgr.c and use uid_t, gid_t types.
 20200511 add first unittest, run with "make test"

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+20200514 code: changed qmail-popup interface (leave kid's fd 2 alone).
 20200511 code: remove tryshsgr.c and use uid_t, gid_t types.
 20200511 add first unittest, run with "make test"
 20191227 fixed possible overflow in alloc() with allocations close to 4GiB

--- a/qmail-pop3d.8
+++ b/qmail-pop3d.8
@@ -22,8 +22,25 @@ under
 .BR qmail-popup ,
 which reads a username and password,
 and
-.BR /bin/checkpassword ,
+.BR checkpassword ,
 which checks the password and sets up environment variables.
+
+Since root will never have a
+.B maildir
+(because
+.B qmail-lspawn
+refuses to run
+.B qmail-local
+as root),
+.B qmail-pop3d
+also refuses to run as root.
+The event will be logged and
+.B qmail-pop3d
+will exit 1, looking to
+.B qmail-popup
+like any other failed
+.B checkpassword
+login.
 
 .B qmail-pop3d
 has a 20-minute idle timeout.

--- a/qmail-popup.8
+++ b/qmail-popup.8
@@ -31,9 +31,8 @@ It reads a username and password from descriptor 0
 in POP's USER-PASS style or APOP style.
 It invokes
 .IR subprogram ,
-with the same descriptors 0 and 1;
-descriptor 2 writing to the network;
-and descriptor 3 reading the username, a 0 byte, the password,
+with the same descriptors 0 and 1,
+and with descriptor 3 reading the username, a 0 byte, the password,
 another 0 byte, 
 an APOP timestamp derived from
 .IR hostname ,

--- a/qmail-popup.c
+++ b/qmail-popup.c
@@ -88,7 +88,6 @@ char *pass;
   int wstat;
   int pi[2];
  
-  if (fd_copy(2,1) == -1) die_pipe();
   close(3);
   if (pipe(pi) == -1) die_pipe();
   if (pi[0] != 3) die_pipe();


### PR DESCRIPTION
At least checkpassword-pam and DJB's original checkpassword are willing
to authenticate the root user and run a child program with UID 0. For
POP3 service -- the canonical checkpassword use case! -- this produces
runtime behavior that is inconsistent with...

- qmail's design, because qmail-local will never run as root to populate
  a Maildir that qmail-pop3d could serve, and

- qmail's security focus, because it lets abusers dictionary-attack the
  root password over the network.

Instead, in qmail-pop3d, if getuid() returns 0, we write to the logs and
exit 1. If someone manages to guess the root password, they won't know
they did: it looks exactly like any other failed checkpassword login.
And the sysadmin could potentially be alerted.