### PR TITLE
correctly detect multiple IP addresses on the same interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+20190919 fix ipme with multiple addresses on the same interface on platforms
+         without sa_len
 20190904 code: use stdint.h to get the definition for uint32
 20190903 code: do not parse header recipients for "qmail-inject -a"
 20190826 code: if $QMAILREMOTE is set, it's invoked instead of qmail-remote.

--- a/ipme.c
+++ b/ipme.c
@@ -89,6 +89,9 @@ int ipme_init()
     len = sizeof(ifr->ifr_name) + ifr->ifr_addr.sa_len;
     if (len < sizeof(*ifr))
       len = sizeof(*ifr);
+#else
+    len = sizeof(*ifr);
+#endif
     if (ifr->ifr_addr.sa_family == AF_INET) {
       sin = (struct sockaddr_in *) &ifr->ifr_addr;
       byte_copy(&ix.ip,4,&sin->sin_addr);
@@ -96,17 +99,6 @@ int ipme_init()
         if (ifr->ifr_flags & IFF_UP)
           if (!ipalloc_append(&ipme,&ix)) { close(s); return 0; }
     }
-#else
-    len = sizeof(*ifr);
-    if (ioctl(s,SIOCGIFFLAGS,x) == 0)
-      if (ifr->ifr_flags & IFF_UP)
-        if (ioctl(s,SIOCGIFADDR,x) == 0)
-	  if (ifr->ifr_addr.sa_family == AF_INET) {
-	    sin = (struct sockaddr_in *) &ifr->ifr_addr;
-	    byte_copy(&ix.ip,4,&sin->sin_addr);
-	    if (!ipalloc_append(&ipme,&ix)) { close(s); return 0; }
-	  }
-#endif
     x += len;
   }
   close(s);


### PR DESCRIPTION
This affects only platforms where ```struct sockaddr``` has no member sa_len. The only system family that we found so far where this is the case and where you indeed can configure multiple IP addresses on the same interface is Linux.

Historically this has not been the case, back in the days of Linux 2.0 and 2.2 you had to create virtual interfaces per physical interface (I remember having "eth0:0" around).

Reason for this is that the code overwrites the IP address in the buffer when checking if the interface is actually up. The code for the sa_len case copied the IP address out to a different buffer first. Moving that code out of the ```#ifdef``` and deleting the wrong code is enough for the fix.

Unrelated to the bug is a change to use a better algorithm to get the needed buffer size in the first place. If you pass an empty buffer to SIOCGIFCONF it will tell you the needed buffer size, but the current code tried to scale it in a look until it is big enough.

Fixes #95.