### PR TITLE
remove obsolete mail client wrappers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+20200520 remove wrappers for obsolete mail clients without maildir support
 20200520 version: notqmail 1.08.
 20200519 bug: fix several other places where variables could overflow.
 20200519 security: fix signedness wraparound in substdio_{put,bput}().

--- a/INSTALL.maildir
+++ b/INSTALL.maildir
@@ -55,5 +55,4 @@ by creating a maildir in the new-user template directory and replacing
 
 Until your MUA supports maildir, you'll probably want to convert maildir
 format to (gaaack) mbox format. I've supplied a maildir2mbox utility
-that does the trick, along with some tiny qail and elq and pinq wrappers
-that call maildir2mbox before calling Mail or elm or pine.
+that does the trick.

--- a/Makefile
+++ b/Makefile
@@ -509,15 +509,6 @@ dot-qmail.9 conf-qmail conf-break conf-spawn
 	| sed s}SPAWN}"`head -1 conf-spawn`"}g \
 	> dot-qmail.5
 
-elq: \
-warn-auto.sh elq.sh conf-qmail conf-break conf-split
-	cat warn-auto.sh deprecated.sh elq.sh \
-	| sed s}QMAIL}"`head -1 conf-qmail`"}g \
-	| sed s}BREAK}"`head -1 conf-break`"}g \
-	| sed s}SPLIT}"`head -1 conf-split`"}g \
-	> elq
-	chmod 755 elq
-
 env.a: \
 makelib env.o envread.o
 	./makelib env.a env.o envread.o
@@ -811,7 +802,7 @@ qmail-pop3d qmail-popup qmail-qmqpc qmail-qmqpd qmail-qmtpd \
 qmail-smtpd sendmail tcp-env qmail-newmrh config config-fast \
 dnsptr dnsip dnsfq hostname ipmeprint qreceipt qsmhook qbiff \
 forward preline condredirect bouncesaying except maildirmake \
-maildir2mbox maildirwatch qail elq pinq install instpackage instchown \
+maildir2mbox maildirwatch install instpackage instchown \
 instcheck home home+df proc proc+df binm1 binm1+df binm2 binm2+df \
 binm3 binm3+df
 
@@ -1002,15 +993,6 @@ package: \
 it man
 	./instpackage
 
-pinq: \
-warn-auto.sh pinq.sh conf-qmail conf-break conf-split
-	cat warn-auto.sh deprecated.sh pinq.sh \
-	| sed s}QMAIL}"`head -1 conf-qmail`"}g \
-	| sed s}BREAK}"`head -1 conf-break`"}g \
-	| sed s}SPLIT}"`head -1 conf-split`"}g \
-	> pinq
-	chmod 755 pinq
-
 predate: \
 load predate.o datetime.a strerr.a sig.a fd.a wait.a substdio.a \
 error.a str.a fs.a
@@ -1058,15 +1040,6 @@ proc+df.sh conf-qmail
 prot.o: \
 compile prot.c prot.h
 	./compile prot.c
-
-qail: \
-warn-auto.sh qail.sh conf-qmail conf-break conf-split
-	cat warn-auto.sh deprecated.sh qail.sh \
-	| sed s}QMAIL}"`head -1 conf-qmail`"}g \
-	| sed s}BREAK}"`head -1 conf-break`"}g \
-	| sed s}SPLIT}"`head -1 conf-split`"}g \
-	> qail
-	chmod 755 qail
 
 qbiff: \
 load qbiff.o headerbody.o hfield.o getln.a env.a open.a stralloc.a \

--- a/TARGETS
+++ b/TARGETS
@@ -312,9 +312,6 @@ maildir2mbox.o
 maildir2mbox
 maildirwatch.o
 maildirwatch
-qail
-elq
-pinq
 hier.o
 install
 instcheck.o

--- a/deprecated.sh
+++ b/deprecated.sh
@@ -1,6 +1,0 @@
-
-echo >&2
-echo "This script is deprecated and will be removed in the next notqmail release." >&2
-echo >&2
-
-sleep 5

--- a/elq.sh
+++ b/elq.sh
@@ -1,1 +1,0 @@
-QMAIL/bin/maildir2mbox && exec elm ${1+"$@"}

--- a/hier.c
+++ b/hier.c
@@ -140,9 +140,6 @@ void hier()
   c(auto_qmail,"bin","maildirmake",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","maildir2mbox",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","maildirwatch",auto_uido,auto_gidq,0755);
-  c(auto_qmail,"bin","qail",auto_uido,auto_gidq,0755);
-  c(auto_qmail,"bin","elq",auto_uido,auto_gidq,0755);
-  c(auto_qmail,"bin","pinq",auto_uido,auto_gidq,0755);
 
   c(auto_qmail,"man/man5","addresses.5",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/cat5","addresses.0",auto_uido,auto_gidq,0644);

--- a/pinq.sh
+++ b/pinq.sh
@@ -1,1 +1,0 @@
-QMAIL/bin/maildir2mbox && exec pine ${1+"$@"}

--- a/qail.sh
+++ b/qail.sh
@@ -1,1 +1,0 @@
-QMAIL/bin/maildir2mbox && exec Mail ${1+"$@"}


### PR DESCRIPTION
These 3 scripts call maildir2mbox before calling one of 3 mail programs. Both elq and pine are obsolete and are not maintained anymore, and I have no idea what "Mail" was. Noone uses any of these today anymore, and most people don't do on local mail stores either.