### PR TITLE
change function signatures to C89 style that were touched since netqmail-1.06

### DIFF
--- a/gid.c
+++ b/gid.c
@@ -6,8 +6,7 @@
 #include "exit.h"
 
 int
-initgid(group)
-  char *group;
+initgid(char *group)
 {
   struct group *gr;
   gr = getgrnam(group);

--- a/instchown.c
+++ b/instchown.c
@@ -8,11 +8,7 @@ extern void hier();
 
 #define FATAL "instchown: fatal: "
 
-void h(home,uid,gid,mode)
-char *home;
-int uid;
-int gid;
-int mode;
+void h(char *home, int uid, int gid, int mode)
 {
   if (chown(home,uid,gid) == -1)
     strerr_die4sys(111,FATAL,"unable to chown ",home,": ");
@@ -20,12 +16,7 @@ int mode;
     strerr_die4sys(111,FATAL,"unable to chmod ",home,": ");
 }
 
-void d(home,subdir,uid,gid,mode)
-char *home;
-char *subdir;
-int uid;
-int gid;
-int mode;
+void d(char *home, char *subdir, int uid, int gid, int mode)
 {
   if (chdir(home) == -1)
     strerr_die4sys(111,FATAL,"unable to switch to ",home,": ");
@@ -35,12 +26,7 @@ int mode;
     strerr_die6sys(111,FATAL,"unable to chmod ",home,"/",subdir,": ");
 }
 
-void p(home,fifo,uid,gid,mode)
-char *home;
-char *fifo;
-int uid;
-int gid;
-int mode;
+void p(char *home, char *fifo, int uid, int gid, int mode)
 {
   if (chdir(home) == -1)
     strerr_die4sys(111,FATAL,"unable to switch to ",home,": ");
@@ -50,13 +36,7 @@ int mode;
     strerr_die6sys(111,FATAL,"unable to chmod ",home,"/",fifo,": ");
 }
 
-void c(home,subdir,file,uid,gid,mode)
-char *home;
-char *subdir;
-char *file;
-int uid;
-int gid;
-int mode;
+void c(char *home, char *subdir, char *file, int uid, int gid, int mode)
 {
   if (chdir(home) == -1)
     strerr_die4sys(111,FATAL,"unable to switch to ",home,": ");
@@ -68,13 +48,7 @@ int mode;
     strerr_die6sys(111,FATAL,"unable to chmod .../",subdir,"/",file,": ");
 }
 
-void z(home,file,len,uid,gid,mode)
-char *home;
-char *file;
-int len;
-int uid;
-int gid;
-int mode;
+void z(char *home, char *file, int len, int uid, int gid, int mode)
 {
   if (chdir(home) == -1)
     strerr_die4sys(111,FATAL,"unable to switch to ",home,": ");

--- a/instpackage.c
+++ b/instpackage.c
@@ -22,9 +22,7 @@ static void die_nomem()
   strerr_die2sys(111,FATAL,"out of memory");
 }
 
-static void ddhome(dd,home)
-stralloc *dd;
-char *home;
+static void ddhome(stralloc *dd, char *home)
 {
   const char *denv = env_get("DESTDIR");
   if (denv)
@@ -34,9 +32,7 @@ char *home;
   if (!stralloc_0(dd)) die_nomem();
 }
 
-static int mkdir_p(home,mode)
-char *home;
-int mode;
+static int mkdir_p(char *home, int mode)
 {
   stralloc parent = { 0 };
   unsigned int sl;
@@ -56,11 +52,7 @@ int mode;
   return mkdir(home,mode);
 }
 
-void h(home,uid,gid,mode)
-char *home;
-int uid;
-int gid;
-int mode;
+void h(char *home, int uid, int gid, int mode)
 {
   stralloc dh = { 0 };
   ddhome(&dh, home);
@@ -73,12 +65,7 @@ int mode;
   alloc_free(dh.s);
 }
 
-void d(home,subdir,uid,gid,mode)
-char *home;
-char *subdir;
-int uid;
-int gid;
-int mode;
+void d(char *home, char *subdir, int uid, int gid, int mode)
 {
   stralloc dh = { 0 };
   ddhome(&dh, home);
@@ -93,12 +80,7 @@ int mode;
   alloc_free(dh.s);
 }
 
-void p(home,fifo,uid,gid,mode)
-char *home;
-char *fifo;
-int uid;
-int gid;
-int mode;
+void p(char *home, char *fifo, int uid, int gid, int mode)
 {
   stralloc dh = { 0 };
   ddhome(&dh, home);
@@ -118,13 +100,7 @@ char outbuf[SUBSTDIO_OUTSIZE];
 substdio ssin;
 substdio ssout;
 
-void c(home,subdir,file,uid,gid,mode)
-char *home;
-char *subdir;
-char *file;
-int uid;
-int gid;
-int mode;
+void c(char *home, char *subdir, char *file, int uid, int gid, int mode)
 {
   int fdin;
   int fdout;
@@ -170,13 +146,7 @@ int mode;
   alloc_free(dh.s);
 }
 
-void z(home,file,len,uid,gid,mode)
-char *home;
-char *file;
-int len;
-int uid;
-int gid;
-int mode;
+void z(char *home, char *file, int len, int uid, int gid, int mode)
 {
   int fdout;
   stralloc dh = { 0 };

--- a/uid.c
+++ b/uid.c
@@ -6,8 +6,7 @@
 #include "exit.h"
 
 int
-inituid(user)
-  char *user;
+inituid(char *user)
 {
   struct passwd *pw;
   pw = getpwnam(user);

--- a/uidgid.h
+++ b/uidgid.h
@@ -1,7 +1,7 @@
 #ifndef UIDGID_H
 #define UIDGID_H
 
-extern int inituid();
-extern int initgid();
+extern int inituid(char *uid);
+extern int initgid(char *gid);
 
 #endif


### PR DESCRIPTION
Those would collide in any external patch anyway, so we can change them to a better interface without extra hassle.