### PR TITLE
Add a test target and one unit test, using Check.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,11 +13,13 @@ task:
         NROFF: true
 
   pkginstall_script:
-    - pkg install -y groff
+    - pkg install -y groff pkgconf check
   configure_script:
     - echo "clang -O2 -Wall" > conf-cc
   compile_script:
     - make it man
+  test_script:
+    - make test
   install_script:
     - env DESTDIR=/tmp/qmail make package
     - make package

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,16 @@ env:
 compiler:
  - gcc
  - clang
+addons:
+  apt:
+    packages:
+    - pkg-config
+    - check
 script:
  - echo "${CC} -O2 -Wall" > conf-cc
  - if [ -n "${FORCE_UTMP}" ]; then cp qtmp.h1 qtmp.h; fi
  - make ${MAKEFLAGS} it man
+ - make test
  - env DESTDIR=/tmp/qmail make ${MAKEFLAGS} package
  - sudo make ${MAKEFLAGS} package
  - sudo groupadd -g 200 nofiles

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+20200511 add first unittest, run with "make test"
 20191227 fixed possible overflow in alloc() with allocations close to 4GiB
 20191226 add missing return types to main()
 20190919 fix ipme with multiple addresses on the same interface on platforms

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ NROFF=nroff
 
 default: it
 
-.PHONY: check clean default it man
+.PHONY: check clean default it man test
 
 %.0:
 	$(NROFF) -man $^ > $@
@@ -352,6 +352,7 @@ exit.h auto_spawn.h
 clean: \
 TARGETS
 	rm -f `cat TARGETS`
+	$(MAKE) -C tests clean
 
 coe.o: \
 compile coe.c coe.h
@@ -2002,6 +2003,9 @@ byte.h datetime.h readwrite.h
 tcpto_clean.o: \
 compile tcpto_clean.c tcpto.h open.h substdio.h readwrite.h
 	./compile tcpto_clean.c
+
+test: it
+	@$(MAKE) -C tests test
 
 timeoutconn.o: \
 compile timeoutconn.c ndelay.h select.h error.h readwrite.h ip.h \

--- a/UNITTESTS.md
+++ b/UNITTESTS.md
@@ -1,0 +1,16 @@
+Before building and running the tests, install [Check](https://libcheck.github.io/check/)
+(and [pkg-config](https://pkg-config.freedesktop.org/) or
+[pkgconf](https://github.com/pkgconf/pkgconf) to find Check's includes and libs). These
+are dependencies for tests and only for tests.
+
+To build and run the tests from the top-level Makefile, simply run:
+
+```shell
+make test
+```
+
+Verified to work with recent BSD and GNU make.
+
+To add more ```stralloc``` tests, copy the ```test_stralloc_thingy``` example in
+```tests/unittest_stralloc.c```. To add other tests, copy the
+```unittest_stralloc``` example in ```tests/Makefile```.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,32 @@
+# Tests require
+# 1. <https://pkg-config.freedesktop.org>
+#    (or <https://github.com/pkgconf/pkgconf>)
+# 2. <https://libcheck.github.io/check/>
+
+SHELL=/bin/sh
+
+default: it
+
+.PHONY: clean default it test
+
+TESTBINS = unittest_stralloc
+
+clean:
+	rm -f $(TESTBINS) *.o
+
+it: $(TESTBINS)
+
+test: it
+	@for tbin in $(TESTBINS); do \
+		./$$tbin || exit 1 ; \
+	done
+
+unittest_stralloc: \
+../load unittest_stralloc.o ../stralloc.a ../alloc.a ../str.a ../error.a
+	../load unittest_stralloc ../stralloc.a ../alloc.a ../str.a ../error.a \
+	`pkg-config --libs check`
+
+unittest_stralloc.o: \
+../compile unittest_stralloc.c ../alloc.h ../stralloc.h
+	../compile unittest_stralloc.c -I.. \
+	`pkg-config --cflags check`

--- a/tests/unittest_stralloc.c
+++ b/tests/unittest_stralloc.c
@@ -1,0 +1,51 @@
+#include <check.h>
+
+#include "alloc.h"
+#include "stralloc.h"
+
+START_TEST(test_stralloc_thingy)
+{
+  stralloc thingy = {0};
+  const char *input = "thingy";
+
+  stralloc_copys(&thingy,input);
+  stralloc_0(&thingy);
+
+  ck_assert_str_eq(input, thingy.s);
+
+  alloc_free(thingy.s);
+}
+END_TEST
+
+TCase
+*stralloc_something(void)
+{
+  TCase *tc = tcase_create("basic operations");
+
+  tcase_add_test(tc, test_stralloc_thingy);
+
+  return tc;
+}
+
+Suite
+*stralloc_suite(void)
+{
+  Suite *s = suite_create("notqmail stralloc");
+
+  suite_add_tcase(s, stralloc_something());
+
+  return s;
+}
+
+int
+main(void)
+{
+  int number_failed;
+
+  SRunner *sr = srunner_create(stralloc_suite());
+  srunner_run_all(sr, CK_NORMAL);
+  number_failed = srunner_ntests_failed(sr);
+  srunner_free(sr);
+
+  return number_failed;
+}

--- a/tests/unittest_stralloc.c
+++ b/tests/unittest_stralloc.c
@@ -17,12 +17,66 @@ START_TEST(test_stralloc_thingy)
 }
 END_TEST
 
+START_TEST(test_stralloc_sizes)
+{
+  stralloc thingy = {0};
+  const char *input = "thingy";
+  unsigned int olen;
+
+  // make room for exactly 42 bytes
+  int r = stralloc_ready(&thingy, 42);
+  ck_assert_int_eq(r, 1);
+  ck_assert_uint_eq(thingy.len, 0);
+  ck_assert_uint_eq(thingy.a, 42);
+  // make sure that there is room for 42 more bytes
+  // given that there are 42 bytes in it and nothing is used this does nothing
+  r = stralloc_readyplus(&thingy, 42);
+  ck_assert_int_eq(r, 1);
+  ck_assert_uint_eq(thingy.len, 0);
+  ck_assert_uint_eq(thingy.a, 42);
+  // make sure there is room for 16 more bytes
+  // there is already more room available, so this does nothing
+  r = stralloc_readyplus(&thingy, 16);
+  ck_assert_int_eq(r, 1);
+  ck_assert_uint_eq(thingy.len, 0);
+  ck_assert_uint_eq(thingy.a, 42);
+
+  r = stralloc_copys(&thingy,input);
+  ck_assert_int_eq(r, 1);
+  ck_assert_uint_eq(thingy.len, strlen(input));
+  ck_assert_uint_eq(thingy.a, 42);
+
+  r = stralloc_0(&thingy);
+  ck_assert_int_eq(r, 1);
+  ck_assert_uint_eq(thingy.len, strlen(input) + 1);
+  ck_assert_uint_eq(thingy.a, 42);
+
+  // make sure that there is room for 42 more bytes
+  r = stralloc_readyplus(&thingy, 42);
+  ck_assert_int_eq(r, 1);
+  ck_assert_uint_eq(thingy.len, strlen(input) + 1);
+  ck_assert_uint_ge(thingy.a, thingy.len + 42);
+  olen = thingy.a;
+
+  // another stralloc_ready should not touch anything
+  r = stralloc_ready(&thingy, 42);
+  ck_assert_int_eq(r, 1);
+  ck_assert_uint_eq(thingy.len, strlen(input) + 1);
+  ck_assert_uint_ge(thingy.a, olen);
+
+  ck_assert_str_eq(input, thingy.s);
+
+  alloc_free(thingy.s);
+}
+END_TEST
+
 TCase
 *stralloc_something(void)
 {
   TCase *tc = tcase_create("basic operations");
 
   tcase_add_test(tc, test_stralloc_thingy);
+  tcase_add_test(tc, test_stralloc_sizes);
 
   return tc;
 }


### PR DESCRIPTION
Had a little time on the plane. Here's an extremely minimal example of a unit test. Not looking for approval yet, just feedback.

You'll need [Check](https://libcheck.github.io/check/doc/check_html/index.html#Top) installed, and depending where it goes you may need to adjust `conf-cc` and `conf-ld` to find it.

Then run `make test` and behold, at least one use of stralloc is shown to work!

I picked stralloc because we all understand it, it's heavily used, it's relatively easy to test, and who knows, maybe with sufficient stralloc tests we'll discover something interesting we'll be glad to know about.