### PR TITLE
remove the need for exit.h in named pipe bug check

### DIFF
--- a/trynpbg1.c
+++ b/trynpbg1.c
@@ -4,7 +4,7 @@
 
 #define FN "temp-trynpbg1.fifo"
 
-void main()
+int main()
 {
   int flagbug;
   struct timeval instant;
@@ -22,5 +22,5 @@ void main()
     }
     unlink(FN);
   }
-  _exit(!flagbug);
+  return !flagbug;
 }


### PR DESCRIPTION
This removes the need for that change from #79.