### PR TITLE
optionally create a systemd service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1532,6 +1532,12 @@ qmail.h substdio.h qsutil.h prioq.h datetime.h gen_alloc.h constmap.h \
 fmtqfn.h readsubdir.h direntry.h
 	./compile qmail-send.c
 
+qmail-send.service: \
+qmail-send.service.in conf-qmail
+	cat qmail-send.service.in \
+	| sed s}QMAILHOME}"`head -1 conf-qmail`"}g \
+	> qmail-send.service
+
 qmail-showctl: \
 load qmail-showctl.o uid.o gid.o auto_usera.o auto_userd.o auto_userl.o \
 auto_usero.o auto_userp.o auto_userq.o auto_userr.o auto_users.o auto_groupn.o \

--- a/TARGETS
+++ b/TARGETS
@@ -399,3 +399,4 @@ envelopes.0
 forgeries.0
 setup
 qtmp.h
+qmail-send.service

--- a/qmail-send.service.in
+++ b/qmail-send.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=notqmail mail delivery daemons
+After=local-fs.target network.target
+
+[Service]
+ExecStart=QMAILHOME/bin/qmail-start ./Maildir/ splogger qmail
+Environment=PATH=QMAILHOME/bin:${PATH}
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is not installed so packagers can decide in which place they prefer to have it installed.

This should go in before 1.08, so either #76 could also be included, or at least simplify it's packaging after the release.