### PR TITLE
make the queue directory world readable

### DIFF
--- a/hier.c
+++ b/hier.c
@@ -49,7 +49,7 @@ void hier()
 
   d(auto_qmail,"alias",auto_uida,auto_gidq,02755);
 
-  d(auto_qmail,"queue",auto_uidq,auto_gidq,0750);
+  d(auto_qmail,"queue",auto_uidq,auto_gidq,0755);
   d(auto_qmail,"queue/pid",auto_uidq,auto_gidq,0700);
   d(auto_qmail,"queue/intd",auto_uidq,auto_gidq,0700);
   d(auto_qmail,"queue/todo",auto_uidq,auto_gidq,0750);


### PR DESCRIPTION
This affects only the queue directory (i.e. /var/qmail/queue) itself, but not any of the subdirectories. The idea is that one can open that directory and then is able to call e.g. fstatvfs() on it. This is e.g. used by Qsmtp to check if a given mail size (by SIZE extension) is too large for the queue and avoid needless network traffic.