### PR TITLE
qmail-remote: remove flagcname, deprecated feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+- 20200614 stop rewriting RCPT TO: domains when they are a CNAME (RFC 5321 5.1)
 - 20200523 doc: give text files .md extensions.
 - 20200523 cleanup: remove qsmhook, replaced by preline.
 - 20200520 remove wrappers for obsolete mail clients without maildir support

--- a/FAQ.md
+++ b/FAQ.md
@@ -11,7 +11,6 @@ document, and <http://qmail.org/> for qmail community contributions.
 2.2. How do I set up a null client?  
 2.3. How do I send outgoing mail through UUCP?  
 2.4. How do I set up a separate queue for a SLIP/PPP link?  
-2.5. How do I deal with "CNAME lookup failed temporarily"?  
 
 3. Routing incoming messages by host  
 3.1. How do I receive mail for another host name?  
@@ -134,16 +133,6 @@ running, give it a HUP.
 2.4. How do I set up a separate queue for a SLIP/PPP link?
 
 Answer: Use serialmail (<https://cr.yp.to/serialmail.html>).
-
-
-2.5. How do I deal with "CNAME lookup failed temporarily"? The log
-showed that a message was deferred for this reason. Why is qmail doing
-CNAME lookups, anyway?
-
-Answer: The SMTP standard does not permit aliased hostnames, so qmail
-has to do a CNAME lookup in DNS for every recipient host. If the
-relevant DNS server is down, qmail defers the message. It will try again
-soon.
 
 
 

--- a/dns.c
+++ b/dns.c
@@ -187,37 +187,6 @@ int flagsearch;
  if (flagsearch) lookup = res_search;
 }
 
-int dns_cname(sa)
-stralloc *sa;
-{
- int r;
- int loop;
- for (loop = 0;loop < 10;++loop)
-  {
-   if (!sa->len) return loop;
-   if (sa->s[sa->len - 1] == ']') return loop;
-   if (sa->s[sa->len - 1] == '.') { --sa->len; continue; }
-   switch(resolve(sa,T_CNAME))
-    {
-     case DNS_MEM: return DNS_MEM;
-     case DNS_SOFT: return DNS_SOFT;
-     case DNS_HARD: return loop;
-     default:
-       while ((r = findname(T_CNAME)) != 2)
-	{
-	 if (r == DNS_SOFT) return DNS_SOFT;
-	 if (r == 1)
-	  {
-	   if (!stralloc_copys(sa,name)) return DNS_MEM;
-	   break;
-	  }
-	}
-       if (r == 2) return loop;
-    }
-  }
- return DNS_HARD; /* alias loop */
-}
-
 #define FMT_IAA 40
 
 static int iaafmt(char *s, struct ip_address *ipa)

--- a/dns.h
+++ b/dns.h
@@ -6,7 +6,6 @@
 #define DNS_MEM -3
 
 void dns_init();
-int dns_cname();
 int dns_mxip();
 int dns_ip();
 int dns_ptr();

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -275,14 +275,9 @@ void smtp()
 stralloc canonhost = {0};
 stralloc canonbox = {0};
 
-void addrmangle(saout,s,flagalias)
-stralloc *saout; /* host has to be canonical, box has to be quoted */
-char *s;
-int *flagalias;
+void addrmangle(stralloc *saout, char *s)
 {
   int j;
- 
-  *flagalias = 0;
  
   j = str_rchr(s,'@');
   if (!s[j]) {
@@ -291,6 +286,7 @@ int *flagalias;
   }
   if (!stralloc_copys(&canonbox,s)) temp_nomem();
   canonbox.len = j;
+  /* box has to be quoted */
   if (!quote(saout,&canonbox)) temp_nomem();
   if (!stralloc_cats(saout,"@")) temp_nomem();
  
@@ -324,8 +320,6 @@ int main(int argc, char **argv)
   unsigned long random;
   char **recips;
   unsigned long prefme;
-  int flagallaliases;
-  int flagalias;
   char *relayhost;
  
   sig_pipeignore();
@@ -353,18 +347,16 @@ int main(int argc, char **argv)
   }
 
 
-  addrmangle(&sender,argv[2],&flagalias);
+  addrmangle(&sender,argv[2]);
  
   if (!saa_readyplus(&reciplist,0)) temp_nomem();
   if (ipme_init() != 1) temp_oserr();
  
-  flagallaliases = 1;
   recips = argv + 3;
   while (*recips) {
     if (!saa_readyplus(&reciplist,1)) temp_nomem();
     reciplist.sa[reciplist.len] = sauninit;
-    addrmangle(reciplist.sa + reciplist.len,*recips,&flagalias);
-    if (!flagalias) flagallaliases = 0;
+    addrmangle(reciplist.sa + reciplist.len,*recips);
     ++reciplist.len;
     ++recips;
   }
@@ -388,7 +380,6 @@ int main(int argc, char **argv)
         prefme = ip.ix[i].pref;
  
   if (relayhost) prefme = 300000;
-  if (flagallaliases) prefme = 500000;
  
   for (i = 0;i < ip.len;++i)
     if (ip.ix[i].pref < prefme)


### PR DESCRIPTION
qmail-remote used to rewrite the RCPT TO: domain when it was a CNAME,
as it was common before 2001.

RFC 5321 (from 2008), Section 5.1 clearly specifies what MTA should do
today:

    The lookup first attempts to locate an MX record associated with the
    name. If a CNAME record is found, the resulting name is processed as
    if it were the initial name.

djb wrote in https://cr.yp.to/im/cname.html:

    Most implementors agree that this feature is not worth the
    implementation costs. I recommend that, before January 2001, sites stop
    relying on client-side CNAME translation, so that implementors can
    safely remove the feature at that time.

Fixes #120.