### PR TITLE
fmt.h prototypes

### DIFF
--- a/fmt.h
+++ b/fmt.h
@@ -4,22 +4,11 @@
 #define FMT_ULONG 40 /* enough space to hold 2^128 - 1 in decimal, plus \0 */
 #define FMT_LEN ((char *) 0) /* convenient abbreviation */
 
-extern unsigned int fmt_uint();
-extern unsigned int fmt_uint0();
-extern unsigned int fmt_xint();
-extern unsigned int fmt_nbbint();
-extern unsigned int fmt_ushort();
-extern unsigned int fmt_xshort();
-extern unsigned int fmt_nbbshort();
-extern unsigned int fmt_ulong();
-extern unsigned int fmt_xlong();
-extern unsigned int fmt_nbblong();
+extern unsigned int fmt_uint(char *, unsigned int);
+extern unsigned int fmt_uint0(char *, unsigned int, unsigned int);
+extern unsigned int fmt_ulong(char *, unsigned long);
 
-extern unsigned int fmt_plusminus();
-extern unsigned int fmt_minus();
-extern unsigned int fmt_0x();
-
-extern unsigned int fmt_str();
-extern unsigned int fmt_strn();
+extern unsigned int fmt_str(char *, char *);
+extern unsigned int fmt_strn(char *, char *, unsigned int);
 
 #endif

--- a/fmt_str.c
+++ b/fmt_str.c
@@ -1,7 +1,6 @@
 #include "fmt.h"
 
-unsigned int fmt_str(s,t)
-register char *s; register char *t;
+unsigned int fmt_str(char *s, char *t)
 {
   register unsigned int len;
   char ch;

--- a/fmt_strn.c
+++ b/fmt_strn.c
@@ -1,7 +1,6 @@
 #include "fmt.h"
 
-unsigned int fmt_strn(s,t,n)
-register char *s; register char *t; register unsigned int n;
+unsigned int fmt_strn(char *s, char *t, unsigned int n)
 {
   register unsigned int len;
   char ch;

--- a/fmt_uint.c
+++ b/fmt_uint.c
@@ -1,6 +1,6 @@
 #include "fmt.h"
 
-unsigned int fmt_uint(s,u) register char *s; register unsigned int u;
+unsigned int fmt_uint(char *s, unsigned int u)
 {
   register unsigned long l; l = u; return fmt_ulong(s,l);
 }

--- a/fmt_uint0.c
+++ b/fmt_uint0.c
@@ -1,6 +1,6 @@
 #include "fmt.h"
 
-unsigned int fmt_uint0(s,u,n) char *s; unsigned int u; unsigned int n;
+unsigned int fmt_uint0(char *s, unsigned int u, unsigned int n)
 {
   unsigned int len;
   len = fmt_uint(FMT_LEN,u);

--- a/fmt_ulong.c
+++ b/fmt_ulong.c
@@ -1,6 +1,6 @@
 #include "fmt.h"
 
-unsigned int fmt_ulong(s,u) register char *s; register unsigned long u;
+unsigned int fmt_ulong(char *s, unsigned long u)
 {
   register unsigned int len; register unsigned long q;
   len = 1; q = u;


### PR DESCRIPTION
First steps towards a prototypification of the headers.

Should not cause merge conflicts with patch sets as these functions are usually untouched.