### PR TITLE
clean up genalloc implementation

### DIFF
--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -1,7 +1,7 @@
 #ifndef GEN_ALLOC_DEFS_H
 #define GEN_ALLOC_DEFS_H
 
-#define GEN_ALLOC_readyplus(ta,type,field,len,a,i,n,x,base,ta_rplus) \
+#define GEN_ALLOC_readyplus(ta,type,field,len,a,base,ta_rplus) \
 static int ta_rplus ## _internal (ta *x, unsigned int n, unsigned int pluslen) \
 { register unsigned int i; \
   if (x->field) { \
@@ -18,11 +18,11 @@ int ta_rplus(ta *x, unsigned int n) \
 
 /* this needs a GEN_ALLOC_readyplus call before as it reuses the internal helper
  * function. */
-#define GEN_ALLOC_ready(ta,type,field,len,a,i,n,x,base,ta_ready) \
+#define GEN_ALLOC_ready(ta,type,field,len,a,base,ta_ready) \
 int ta_ready(ta *x, unsigned int n) \
 { return ta_ready ## plus_internal (x, n, 0); }
 
-#define GEN_ALLOC_append(ta,type,field,len,a,i,n,x,base,ta_rplus,ta_append) \
+#define GEN_ALLOC_append(ta,type,field,len,a,base,ta_rplus,ta_append) \
 int ta_append(ta *x, type *i) \
 { if (!ta_rplus(x,1)) return 0; x->field[x->len++] = *i; return 1; }
 

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -2,30 +2,25 @@
 #define GEN_ALLOC_DEFS_H
 
 #define GEN_ALLOC_readyplus(ta,type,field,len,a,i,n,x,base,ta_rplus) \
-int ta_rplus(x,n) register ta *x; register unsigned int n; \
+static int ta_rplus ## _internal (register ta *x, register unsigned int n, unsigned int pluslen) \
 { register unsigned int i; \
   if (x->field) { \
-    i = x->a; n += x->len; \
+    i = x->a; n += pluslen; \
     if (n > i) { \
       x->a = base + n + (n >> 3); \
       if (alloc_re(&x->field,i * sizeof(type),x->a * sizeof(type))) return 1; \
       x->a = i; return 0; } \
     return 1; } \
   x->len = 0; \
-  return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); }
+  return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); } \
+int ta_rplus(x,n) register ta *x; register unsigned int n; \
+{ return ta_rplus ## _internal (x, n, x->len); }
 
+/* this needs a GEN_ALLOC_readyplus call before as it reuses the internal helper
+ * function. */
 #define GEN_ALLOC_ready(ta,type,field,len,a,i,n,x,base,ta_ready) \
 int ta_ready(x,n) register ta *x; register unsigned int n; \
-{ register unsigned int i; \
-  if (x->field) { \
-    i = x->a; \
-    if (n > i) { \
-      x->a = base + n + (n >> 3); \
-      if (alloc_re(&x->field,i * sizeof(type),x->a * sizeof(type))) return 1; \
-      x->a = i; return 0; } \
-    return 1; } \
-  x->len = 0; \
-  return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); }
+{ return ta_ready ## plus_internal (x, n, 0); }
 
 #define GEN_ALLOC_append(ta,type,field,len,a,i,n,x,base,ta_rplus,ta_append) \
 int ta_append(x,i) register ta *x; register type *i; \

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -1,6 +1,8 @@
 #ifndef GEN_ALLOC_DEFS_H
 #define GEN_ALLOC_DEFS_H
 
+#include "alloc.h"
+
 #define GEN_ALLOC_readyplus(ta,type,field,len,a,base,ta_rplus) \
 static int ta_rplus ## _internal (ta *x, unsigned int n, unsigned int pluslen) \
 { \

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -3,13 +3,16 @@
 
 #define GEN_ALLOC_readyplus(ta,type,field,len,a,base,ta_rplus) \
 static int ta_rplus ## _internal (ta *x, unsigned int n, unsigned int pluslen) \
-{ register unsigned int i; \
+{ \
   if (x->field) { \
-    i = x->a; n += pluslen; \
-    if (n > i) { \
-      x->a = base + n + (n >> 3); \
-      if (alloc_re(&x->field,i * sizeof(type),x->a * sizeof(type))) return 1; \
-      x->a = i; return 0; } \
+    unsigned int nnum; \
+    n += pluslen; \
+    if (n <= x->a) \
+      return 1; \
+    nnum = base + n + (n >> 3); \
+    if (!alloc_re(&x->field,x->a * sizeof(type),nnum * sizeof(type))) \
+      return 0; \
+    x->a = nnum; \
     return 1; } \
   x->len = 0; \
   return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); } \

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -1,11 +1,11 @@
 #ifndef GEN_ALLOC_DEFS_H
 #define GEN_ALLOC_DEFS_H
 
-#define GEN_ALLOC_ready(ta,type,field,len,a,i,n,x,base,ta_ready) \
-int ta_ready(x,n) register ta *x; register unsigned int n; \
+#define GEN_ALLOC_readyplus(ta,type,field,len,a,i,n,x,base,ta_rplus) \
+int ta_rplus(x,n) register ta *x; register unsigned int n; \
 { register unsigned int i; \
   if (x->field) { \
-    i = x->a; \
+    i = x->a; n += x->len; \
     if (n > i) { \
       x->a = base + n + (n >> 3); \
       if (alloc_re(&x->field,i * sizeof(type),x->a * sizeof(type))) return 1; \
@@ -14,11 +14,11 @@ int ta_ready(x,n) register ta *x; register unsigned int n; \
   x->len = 0; \
   return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); }
 
-#define GEN_ALLOC_readyplus(ta,type,field,len,a,i,n,x,base,ta_rplus) \
-int ta_rplus(x,n) register ta *x; register unsigned int n; \
+#define GEN_ALLOC_ready(ta,type,field,len,a,i,n,x,base,ta_ready) \
+int ta_ready(x,n) register ta *x; register unsigned int n; \
 { register unsigned int i; \
   if (x->field) { \
-    i = x->a; n += x->len; \
+    i = x->a; \
     if (n > i) { \
       x->a = base + n + (n >> 3); \
       if (alloc_re(&x->field,i * sizeof(type),x->a * sizeof(type))) return 1; \

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -15,7 +15,11 @@ static int ta_rplus ## _internal (ta *x, unsigned int n, unsigned int pluslen) \
     x->a = nnum; \
     return 1; } \
   x->len = 0; \
-  return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); } \
+  x->field = (type *) alloc(n * sizeof(type)); \
+  if (!x->field) \
+    return 0; \
+  x->a = n; \
+  return 1; } \
 int ta_rplus(ta *x, unsigned int n) \
 { return ta_rplus ## _internal (x, n, x->len); }
 

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -2,7 +2,7 @@
 #define GEN_ALLOC_DEFS_H
 
 #define GEN_ALLOC_readyplus(ta,type,field,len,a,i,n,x,base,ta_rplus) \
-static int ta_rplus ## _internal (register ta *x, register unsigned int n, unsigned int pluslen) \
+static int ta_rplus ## _internal (ta *x, unsigned int n, unsigned int pluslen) \
 { register unsigned int i; \
   if (x->field) { \
     i = x->a; n += pluslen; \
@@ -13,17 +13,17 @@ static int ta_rplus ## _internal (register ta *x, register unsigned int n, unsig
     return 1; } \
   x->len = 0; \
   return !!(x->field = (type *) alloc((x->a = n) * sizeof(type))); } \
-int ta_rplus(x,n) register ta *x; register unsigned int n; \
+int ta_rplus(ta *x, unsigned int n) \
 { return ta_rplus ## _internal (x, n, x->len); }
 
 /* this needs a GEN_ALLOC_readyplus call before as it reuses the internal helper
  * function. */
 #define GEN_ALLOC_ready(ta,type,field,len,a,i,n,x,base,ta_ready) \
-int ta_ready(x,n) register ta *x; register unsigned int n; \
+int ta_ready(ta *x, unsigned int n) \
 { return ta_ready ## plus_internal (x, n, 0); }
 
 #define GEN_ALLOC_append(ta,type,field,len,a,i,n,x,base,ta_rplus,ta_append) \
-int ta_append(x,i) register ta *x; register type *i; \
+int ta_append(ta *x, type *i) \
 { if (!ta_rplus(x,1)) return 0; x->field[x->len++] = *i; return 1; }
 
 #endif

--- a/ipalloc.c
+++ b/ipalloc.c
@@ -1,4 +1,3 @@
-#include "alloc.h"
 #include "gen_allocdefs.h"
 #include "ip.h"
 #include "ipalloc.h"

--- a/ipalloc.c
+++ b/ipalloc.c
@@ -3,5 +3,5 @@
 #include "ip.h"
 #include "ipalloc.h"
 
-GEN_ALLOC_readyplus(ipalloc,struct ip_mx,ix,len,a,i,n,x,10,ipalloc_readyplus)
-GEN_ALLOC_append(ipalloc,struct ip_mx,ix,len,a,i,n,x,10,ipalloc_readyplus,ipalloc_append)
+GEN_ALLOC_readyplus(ipalloc,struct ip_mx,ix,len,a,10,ipalloc_readyplus)
+GEN_ALLOC_append(ipalloc,struct ip_mx,ix,len,a,10,ipalloc_readyplus,ipalloc_append)

--- a/prioq.c
+++ b/prioq.c
@@ -2,7 +2,7 @@
 #include "gen_allocdefs.h"
 #include "prioq.h"
 
-GEN_ALLOC_readyplus(prioq,struct prioq_elt,p,len,a,i,n,x,100,prioq_readyplus)
+GEN_ALLOC_readyplus(prioq,struct prioq_elt,p,len,a,100,prioq_readyplus)
 
 int prioq_insert(pq,pe)
 prioq *pq;

--- a/prioq.c
+++ b/prioq.c
@@ -1,4 +1,3 @@
-#include "alloc.h"
 #include "gen_allocdefs.h"
 #include "prioq.h"
 

--- a/qmail-inject.c
+++ b/qmail-inject.c
@@ -4,7 +4,6 @@
 #include "subfd.h"
 #include "sgetopt.h"
 #include "getln.h"
-#include "alloc.h"
 #include "str.h"
 #include "fmt.h"
 #include "hfield.h"

--- a/qmail-inject.c
+++ b/qmail-inject.c
@@ -77,7 +77,7 @@ void doordie(sa,r) stralloc *sa; int r; {
  substdio_putflush(subfderr,sa->s,sa->len); perm(); }
 
 GEN_ALLOC_typedef(saa,stralloc,sa,len,a)
-GEN_ALLOC_readyplus(saa,stralloc,sa,len,a,i,n,x,10,saa_readyplus)
+GEN_ALLOC_readyplus(saa,stralloc,sa,len,a,10,saa_readyplus)
 
 static stralloc sauninit = {0};
 

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -35,7 +35,7 @@
 unsigned long port = PORT_SMTP;
 
 GEN_ALLOC_typedef(saa,stralloc,sa,len,a)
-GEN_ALLOC_readyplus(saa,stralloc,sa,len,a,i,n,x,10,saa_readyplus)
+GEN_ALLOC_readyplus(saa,stralloc,sa,len,a,10,saa_readyplus)
 static stralloc sauninit = {0};
 
 stralloc helohost = {0};

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -12,7 +12,6 @@
 #include "auto_qmail.h"
 #include "control.h"
 #include "dns.h"
-#include "alloc.h"
 #include "quote.h"
 #include "ip.h"
 #include "ipalloc.h"

--- a/qreceipt.c
+++ b/qreceipt.c
@@ -4,7 +4,6 @@
 #include "stralloc.h"
 #include "subfd.h"
 #include "getln.h"
-#include "alloc.h"
 #include "str.h"
 #include "hfield.h"
 #include "token822.h"

--- a/stralloc_eady.c
+++ b/stralloc_eady.c
@@ -1,4 +1,3 @@
-#include "alloc.h"
 #include "stralloc.h"
 #include "gen_allocdefs.h"
 

--- a/stralloc_eady.c
+++ b/stralloc_eady.c
@@ -2,5 +2,5 @@
 #include "stralloc.h"
 #include "gen_allocdefs.h"
 
-GEN_ALLOC_readyplus(stralloc,char,s,len,a,i,n,x,30,stralloc_readyplus)
-GEN_ALLOC_ready(stralloc,char,s,len,a,i,n,x,30,stralloc_ready)
+GEN_ALLOC_readyplus(stralloc,char,s,len,a,30,stralloc_readyplus)
+GEN_ALLOC_ready(stralloc,char,s,len,a,30,stralloc_ready)

--- a/stralloc_eady.c
+++ b/stralloc_eady.c
@@ -2,5 +2,5 @@
 #include "stralloc.h"
 #include "gen_allocdefs.h"
 
-GEN_ALLOC_ready(stralloc,char,s,len,a,i,n,x,30,stralloc_ready)
 GEN_ALLOC_readyplus(stralloc,char,s,len,a,i,n,x,30,stralloc_readyplus)
+GEN_ALLOC_ready(stralloc,char,s,len,a,i,n,x,30,stralloc_ready)

--- a/stralloc_pend.c
+++ b/stralloc_pend.c
@@ -1,4 +1,3 @@
-#include "alloc.h"
 #include "stralloc.h"
 #include "gen_allocdefs.h"
 

--- a/stralloc_pend.c
+++ b/stralloc_pend.c
@@ -2,4 +2,4 @@
 #include "stralloc.h"
 #include "gen_allocdefs.h"
 
-GEN_ALLOC_append(stralloc,char,s,len,a,i,n,x,30,stralloc_readyplus,stralloc_append)
+GEN_ALLOC_append(stralloc,char,s,len,a,30,stralloc_readyplus,stralloc_append)

--- a/token822.c
+++ b/token822.c
@@ -22,9 +22,9 @@ token822_alloc *ta;
   }
 }
 
-GEN_ALLOC_readyplus(token822_alloc,struct token822,t,len,a,i,n,x,30,token822_readyplus)
-GEN_ALLOC_ready(token822_alloc,struct token822,t,len,a,i,n,x,30,token822_ready)
-GEN_ALLOC_append(token822_alloc,struct token822,t,len,a,i,n,x,30,token822_readyplus,token822_append)
+GEN_ALLOC_readyplus(token822_alloc,struct token822,t,len,a,30,token822_readyplus)
+GEN_ALLOC_ready(token822_alloc,struct token822,t,len,a,30,token822_ready)
+GEN_ALLOC_append(token822_alloc,struct token822,t,len,a,30,token822_readyplus,token822_append)
 
 static int needspace(t1,t2)
 int t1;

--- a/token822.c
+++ b/token822.c
@@ -22,8 +22,8 @@ token822_alloc *ta;
   }
 }
 
-GEN_ALLOC_ready(token822_alloc,struct token822,t,len,a,i,n,x,30,token822_ready)
 GEN_ALLOC_readyplus(token822_alloc,struct token822,t,len,a,i,n,x,30,token822_readyplus)
+GEN_ALLOC_ready(token822_alloc,struct token822,t,len,a,i,n,x,30,token822_ready)
 GEN_ALLOC_append(token822_alloc,struct token822,t,len,a,i,n,x,30,token822_readyplus,token822_append)
 
 static int needspace(t1,t2)

--- a/token822.c
+++ b/token822.c
@@ -1,5 +1,4 @@
 #include "stralloc.h"
-#include "alloc.h"
 #include "str.h"
 #include "token822.h"
 #include "gen_allocdefs.h"


### PR DESCRIPTION
This code is best described as 90ies style function templates in C. This reduces the code duplication between the ```*_readyplus``` and ```*_ready``` functions, which only differ slightly. Then the code is a bit de-obfuscated. I have used the additional unittest now in #102 to verify that things still behave the same.