### PR TITLE
remove unused substdio_bget()

### DIFF
--- a/substdi.c
+++ b/substdi.c
@@ -50,19 +50,6 @@ register substdio *s;
   return r;
 }
 
-int substdio_bget(s,buf,len)
-register substdio *s;
-register char *buf;
-register int len;
-{
-  register int r;
- 
-  if (s->p > 0) return getthis(s,buf,len);
-  r = s->n; if (r <= len) return oneread(s->op,s->fd,buf,r);
-  r = substdio_feed(s); if (r <= 0) return r;
-  return getthis(s,buf,len);
-}
-
 int substdio_get(s,buf,len)
 register substdio *s;
 register char *buf;

--- a/substdio.h
+++ b/substdio.h
@@ -22,7 +22,6 @@ extern int substdio_bputs();
 extern int substdio_putsflush();
 
 extern int substdio_get();
-extern int substdio_bget();
 extern int substdio_feed();
 
 extern char *substdio_peek();


### PR DESCRIPTION
Spotted by Qualsys during their audit.