### PR TITLE
Docker/Podman builds for notqmail

### DIFF
--- a/docker/Dockerfile.CentOS7
+++ b/docker/Dockerfile.CentOS7
@@ -1,0 +1,36 @@
+FROM centos:7
+MAINTAINER cprogrammer
+
+# Freshen RUN yum update
+RUN mkdir -p /root /usr/libexec/notqmail \
+	&& yum -y install \
+		deltarpm \
+	&& yum -y update \
+	&& yum -y install \
+		gnupg2 \
+		binutils \
+		hostname \
+		mailx \
+		net-tools \
+		openssl \
+		procps \
+		psmisc \
+		telnet \
+		wget \
+		which \
+	&& wget \
+		https://download.opensuse.org/repositories/home:notqmail/CentOS_7/home:notqmail.repo \
+		-O /etc/yum.repos.d/notqmail.repo \
+	&& yum -y install notqmail \
+	&& (echo "/var/qmail/alias/Maildir/" > /var/qmail/alias/.qmail-root; \
+		mkdir -p /var/qmail/alias/Maildir/tmp; \
+		mkdir -p /var/qmail/alias/Maildir/new; \
+		mkdir -p /var/qmail/alias/Maildir/cur; \
+		chown -R alias:qmail /var/qmail/alias/Maildir) \
+	&& (alternatives --install /usr/sbin/sendmail mta /var/qmail/bin/sendmail 120 \
+        --slave /usr/bin/mailq mta-mailq /var/qmail/bin/qmail-qread \
+        --slave /usr/lib/sendmail mta-sendmail /var/qmail/bin/sendmail) \
+	&& ln -s /usr/libexec/notqmail/docker-entrypoint /usr/sbin/docker-entrypoint
+COPY docker-entrypoint config-fast /usr/libexec/notqmail
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["notqmail"]

--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -1,0 +1,37 @@
+# docker build -f dockerfile.focal -t cprogrammer/indimail:focal
+# run dpkg-reconfigure tzdata after starting the container
+From ubuntu:bionic
+MAINTAINER cprogrammer
+
+# Freshen RUN apt-get -y update
+RUN export DEBIAN_FRONTEND=noninteractive \
+	&& mkdir -p /root /usr/libexec/notqmail \
+	&& apt-get -y update \
+	&& apt-get -y install wget gnupg2 apt-utils \
+	&& wget -nv https://download.opensuse.org/repositories/home:notqmail/xUbuntu_18.04/Release.key -O - | apt-key add - \
+	&& echo 'deb http://download.opensuse.org/repositories/home:/notqmail/xUbuntu_18.04/ /' > /etc/apt/sources.list.d/notqmail.list \
+	&& apt-get -y update \
+	&& apt-get -y install \
+		debianutils \
+		binutils \
+		net-tools \
+		openssl \
+		procps \
+		psmisc \
+		rsyslog \
+		telnet \
+		notqmail \
+	&& (sed -i -e 's{^module(load="imklog".*{#&{' /etc/rsyslog.conf; \
+		echo "/var/qmail/alias/Maildir/" > /var/qmail/alias/.qmail-root; \
+		mkdir -p /var/qmail/alias/Maildir/tmp; \
+		mkdir -p /var/qmail/alias/Maildir/new; \
+		mkdir -p /var/qmail/alias/Maildir/cur; \
+		chown -R alias:qmail /var/qmail/alias/Maildir) \
+	&& (update-alternatives --install /usr/sbin/sendmail mta /var/qmail/bin/sendmail 120 \
+        --slave /usr/bin/mailq mta-mailq /var/qmail/bin/qmail-qread \
+        --slave /usr/lib/sendmail mta-sendmail /var/qmail/bin/sendmail) \
+	&& ln -s /usr/libexec/notqmail/docker-entrypoint /usr/sbin/docker-entrypoint \
+	&& unset DEBIAN_FRONTEND
+COPY docker-entrypoint config-fast /usr/libexec/notqmail
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["notqmail"]

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -1,0 +1,37 @@
+# docker build -f dockerfile.focal -t cprogrammer/indimail:focal
+# run dpkg-reconfigure tzdata after starting the container
+From ubuntu:focal
+MAINTAINER cprogrammer
+
+# Freshen RUN apt-get -y update
+RUN export DEBIAN_FRONTEND=noninteractive \
+	&& mkdir -p /root /usr/libexec/notqmail \
+	&& apt-get -y update \
+	&& apt-get -y install wget gnupg2 apt-utils \
+	&& wget -nv https://download.opensuse.org/repositories/home:notqmail/xUbuntu_20.04/Release.key -O - | apt-key add - \
+	&& echo 'deb http://download.opensuse.org/repositories/home:/notqmail/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/notqmail.list \
+	&& apt-get -y update \
+	&& apt-get -y install \
+		debianutils \
+		binutils \
+		net-tools \
+		openssl \
+		procps \
+		psmisc \
+		rsyslog \
+		telnet \
+		notqmail \
+	&& (sed -i -e 's{^module(load="imklog".*{#&{' /etc/rsyslog.conf; \
+		echo "/var/qmail/alias/Maildir/" > /var/qmail/alias/.qmail-root; \
+		mkdir -p /var/qmail/alias/Maildir/tmp; \
+		mkdir -p /var/qmail/alias/Maildir/new; \
+		mkdir -p /var/qmail/alias/Maildir/cur; \
+		chown -R alias:qmail /var/qmail/alias/Maildir) \
+	&& (update-alternatives --install /usr/sbin/sendmail mta /var/qmail/bin/sendmail 120 \
+        --slave /usr/bin/mailq mta-mailq /var/qmail/bin/qmail-qread \
+        --slave /usr/lib/sendmail mta-sendmail /var/qmail/bin/sendmail) \
+	&& ln -s /usr/libexec/notqmail/docker-entrypoint /usr/sbin/docker-entrypoint \
+	&& unset DEBIAN_FRONTEND
+COPY docker-entrypoint config-fast /usr/libexec/notqmail
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["notqmail"]

--- a/docker/Dockerfile.xenial
+++ b/docker/Dockerfile.xenial
@@ -1,0 +1,37 @@
+# docker build -f dockerfile.focal -t cprogrammer/indimail:focal
+# run dpkg-reconfigure tzdata after starting the container
+From ubuntu:xenial
+MAINTAINER cprogrammer
+
+# Freshen RUN apt-get -y update
+RUN export DEBIAN_FRONTEND=noninteractive \
+	&& mkdir -p /root /usr/libexec/notqmail \
+	&& apt-get -y update \
+	&& apt-get -y install wget gnupg2 apt-utils \
+	&& wget -nv https://download.opensuse.org/repositories/home:notqmail/xUbuntu_16.04/Release.key -O - | apt-key add - \
+	&& echo 'deb http://download.opensuse.org/repositories/home:/notqmail/xUbuntu_16.04/ /' > /etc/apt/sources.list.d/notqmail.list \
+	&& apt-get -y update \
+	&& apt-get -y install \
+		debianutils \
+		binutils \
+		net-tools \
+		openssl \
+		procps \
+		psmisc \
+		rsyslog \
+		telnet \
+		notqmail \
+	&& (sed -i -e 's{^module(load="imklog".*{#&{' /etc/rsyslog.conf; \
+		echo "/var/qmail/alias/Maildir/" > /var/qmail/alias/.qmail-root; \
+		mkdir -p /var/qmail/alias/Maildir/tmp; \
+		mkdir -p /var/qmail/alias/Maildir/new; \
+		mkdir -p /var/qmail/alias/Maildir/cur; \
+		chown -R alias:qmail /var/qmail/alias/Maildir) \
+	&& (update-alternatives --install /usr/sbin/sendmail mta /var/qmail/bin/sendmail 120 \
+        --slave /usr/bin/mailq mta-mailq /var/qmail/bin/qmail-qread \
+        --slave /usr/lib/sendmail mta-sendmail /var/qmail/bin/sendmail) \
+	&& ln -s /usr/libexec/notqmail/docker-entrypoint /usr/sbin/docker-entrypoint \
+	&& unset DEBIAN_FRONTEND
+COPY docker-entrypoint config-fast /usr/libexec/notqmail
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["notqmail"]

--- a/docker/docker-entrypoint
+++ b/docker/docker-entrypoint
@@ -1,0 +1,37 @@
+#!/bin/sh
+# WARNING: This file was auto-generated. Do not edit!
+#
+set -e
+
+case "$1" in
+notqmail)
+	if [ ! -f /etc/mtab ] ; then
+		if [ -f /proc/self/mounts ] ; then
+			echo "Warning  linking /etc/mtab to /proc/self/mounts" 1>&2
+			ln -s /proc/self/mounts /etc/mtab
+		elif [ -f /proc/mounts ] ; then
+			echo "Warning  linking /etc/mtab to /proc/mounts" 1>&2
+			ln -s /proc/mounts /etc/mtab
+		else
+			echo "Warning /etc/mtab: No such file or directory" 1>&2
+		fi
+	fi
+	if [ ! -f /var/qmail/control/me ] ; then
+		HOSTNAME=`hostname`
+		echo $HOSTNAME > /var/qmail/control/me
+		/usr/libexec/notqmail/config-fast $HOSTNAME
+	fi
+	# this is a minimal system
+	# start system logger for splogger to log entries
+	if [ -x /usr/lib/systemd/systemd-journald ] ; then
+		/usr/lib/systemd/systemd-journald &
+	elif [ -f /etc/init.d/rsyslog ] ; then
+		/etc/init.d/rsyslog start
+	fi
+	exec env PATH=/var/qmail/bin:$PATH qmail-start ./Maildir/ splogger qmail
+;;
+*)
+	echo "docker-entrypoint: executing $@"
+	exec "$@"
+;;
+esac


### PR DESCRIPTION
# Dockerfile repository for automated builds.
  
This repo contains repository for Dockerfiles used for building
docker/podman images for notqmail

https://hub.docker.com/r/docker_username/notqmail

The following tags/images can be pulled by executing
the commands

## a) docker

```
docker pull docker_user/notqmail:tag
```

or

## b) podman

```
podman pull docker_user/notqmail:tag
```

Replace tag in the above command with one of the following
```
xenial     for Ubuntu 16.04
bionic     for Ubuntu 18.04
focal      for Ubuntu 20.04
centos7    for CentOS 7
centos8    for CentOS 8
debian8    for Debian 8
debian9    for Debian 9
debian10   for Debian 10
fc31       for Fedora Core 31
fc32       for Fedora Core 32
Tumbleweed for openSUSE Tumbleweed
Leap15.2   for openSUSE Leap 15.2
```

## Instructions for starting the docker/podman container
(replace podman with docker for docker operations)

### list podman images

$ podman images
```
REPOSITORY                           TAG       IMAGE ID       CREATED          SIZE
localhost/notqmail                   centos7   4bcbc7a876fe   38 minutes ago   452 MB
localhost/notqmail                   focal     d3b533841934   2 hours ago      141 MB
```

### Start the podman container

notqmail uses docker-entrypoint to execute qmail-start and start qmail-send, qmail-lspawn, qmail-rspawn.
You just need to pass any argument other than notqmail to bypass the default entrypoint.

$ podman run -d -h notqmail.org --name notqmail d3b533841934
```
08a4df5054d920cfdf8869aa777a7afc39bab19591394ea283c0c082f8b0a876
```

You can use --net host to map the container's network to the HOST
```
$ docker run --net host -d -h notqmail.org --name notqmail d3b533841934
or
$ podman run --net host -d -h notqmail.org --name notqmail d3b533841934
```

### Query the id of the container

$ podman ps
```
CONTAINER ID  IMAGE                                   COMMAND   CREATED             STATUS                 PORTS  NAMES
08a4df5054d9  docker.io/cprogrammer/notqmail:focal    notqmail  About a minute ago  Up About a minute ago         notqmail
```

### Execute an interactive shell in the container

$ podman exec -ti notqmail /bin/bash
```
root@notqmail:/#
```

### Get processlist in the container

```
root@notqmail:/# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
qmails         1       0  0 10:10 pts/0    00:00:00 qmail-send
qmaill        35       1  0 10:10 pts/0    00:00:00 splogger qmail
root          36       1  0 10:10 pts/0    00:00:00 qmail-lspawn ./Maildir/
qmailr        37       1  0 10:10 pts/0    00:00:00 qmail-rspawn
qmailq        38       1  0 10:10 pts/0    00:00:00 qmail-clean
syslog        50       1  0 10:10 ?        00:00:00 /usr/sbin/rsyslogd
root          66       0 40 10:22 pts/1    00:00:00 bash
root          75      66  0 10:22 pts/1    00:00:00 ps -ef
root@notqmail:/#
```

### Get console logs of the container
```
$ podman logs
Warning  linking /etc/mtab to /proc/self/mounts
Your fully qualified host name is notqmail.org.
Putting notqmail.org into /var/qmail/control/me...
Putting notqmail.org into /var/qmail/control/defaulthost...
Putting notqmail.org into /var/qmail/control/envnoathost...
Putting notqmail.org into /var/qmail/control/defaultdomain...
Putting notqmail.org into /var/qmail/control/plusdomain...
Putting notqmail.org into /var/qmail/control/locals...
Putting notqmail.org into //var/qmail/control/rcpthosts...
Now qmail will refuse to accept SMTP messages except to the following...
notqmail.org
Make sure to change rcpthosts if you add hosts to locals or virtualdomains!
 * Starting enhanced syslogd rsyslogd
```

### Stop the container

$ podman stop \`podman ps -q\`
```
08a4df5054d920cfdf8869aa777a7afc39bab19591394ea283c0c082f8b0a876
```

### Clear the stopped container image

$ podman rm \`podman ps -aq\`
```
08a4df5054d920cfdf8869aa777a7afc39bab19591394ea283c0c082f8b0a876
```

## c) github respository for Dockerfile

The Dockerfile for each of the images is located in a separate subdirectory for each linux distro

**notqmail**
https://github.com/notqmail/docker/tree/master/notqmail

If you want to build the image yourself instead of using hub.docker.com,
you can use the below commands

```
$ docker build -t notqmail:focal ./Dockerfile.focal .
or
$ podman build -t notqmail:focal ./Dockerfile.focal .
```

## NOTE THIS FILE REQUIRES Editing after completing following steps ##
1. create a user on hub.docker.com (docker_user)
2. Create a repository for docker files and update point c) above
Take a look at

https://github.com/mbhangui/docker
&
https://hub.docker.com/repository/docker/cprogrammer/indimail-mta
