### PR TITLE
make most output of auto-str readable

### DIFF
--- a/auto-str.c
+++ b/auto-str.c
@@ -1,3 +1,4 @@
+#include <ctype.h>
 #include "substdio.h"
 #include "readwrite.h"
 #include "exit.h"
@@ -9,6 +10,17 @@ void puts(s)
 char *s;
 {
   if (substdio_puts(&ss1,s) == -1) _exit(111);
+}
+
+// check if a given character can be printed unquoted in a C string
+// does not accept digits as they may be hardly visible between octal encoded chars
+static int is_legible(unsigned char ch)
+{
+  if (isascii(ch))
+    return 1;
+  if (ch == '/' || ch == '_' || ch == '-' || ch == '.')
+    return 1;
+  return 0;
 }
 
 void main(argc,argv)
@@ -30,12 +42,17 @@ char **argv;
   puts("[] = \"\\\n");
 
   while (ch = *value++) {
-    puts("\\");
-    octal[3] = 0;
-    octal[2] = '0' + (ch & 7); ch >>= 3;
-    octal[1] = '0' + (ch & 7); ch >>= 3;
-    octal[0] = '0' + (ch & 7);
-    puts(octal);
+    if (is_legible(ch)) {
+      if (substdio_put(&ss1, &ch, 1) == -1)
+        _exit(111);
+    } else {
+      puts("\\");
+      octal[3] = 0;
+      octal[2] = '0' + (ch & 7); ch >>= 3;
+      octal[1] = '0' + (ch & 7); ch >>= 3;
+      octal[0] = '0' + (ch & 7);
+      puts(octal);
+    }
   }
 
   puts("\\\n\";\n");


### PR DESCRIPTION
Avoid recoding letters and anything from "/.-_" into octal, just print them directly.