### PR TITLE
predate: use better version of calling time()

### DIFF
--- a/predate.c
+++ b/predate.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
   close(pi[0]);
   substdio_fdbuf(&ss,write,pi[1],outbuf,sizeof(outbuf));
 
-  time(&now);
+  now = time(NULL);
 
   tm = gmtime(&now);
   dt.year = tm->tm_year;


### PR DESCRIPTION
From time(2):

```
The tloc argument is obsolescent and should always be NULL in new code. When tloc is NULL, the call cannot fail.
```

This is old code, but when we can prevent it from failing this is a good thing in any case.