### PR TITLE
replace alloc_re() with plain realloc()

### DIFF
--- a/alloc.h
+++ b/alloc.h
@@ -5,9 +5,9 @@
 
 #define alloc(x) malloc(x)
 #define alloc_free(x) free(x)
-static inline int alloc_re(char **x, unsigned int m, unsigned int n)
+static inline int alloc_re(void **x, unsigned int m, unsigned int n)
 {
-  char *y = realloc(*x, n);
+  void *y = realloc(*x, n);
   (void)m;
   if (y != NULL)
     *x = y;

--- a/alloc.h
+++ b/alloc.h
@@ -5,13 +5,5 @@
 
 #define alloc(x) malloc(x)
 #define alloc_free(x) free(x)
-static inline int alloc_re(void **x, unsigned int m, unsigned int n)
-{
-  void *y = realloc(*x, n);
-  (void)m;
-  if (y != NULL)
-    *x = y;
-  return !!y;
-}
 
 #endif

--- a/env.c
+++ b/env.c
@@ -54,9 +54,12 @@ static int env_add(s) char *s;
  if (t) env_unsetlen(s,t - s);
  if (en == ea)
   {
+   char **nenv;
    ea += 30;
-   if (!alloc_re((void**)&environ,(en + 1) * sizeof(char *),(ea + 1) * sizeof(char *)))
+   nenv = realloc(environ, (ea + 1) * sizeof(char *));
+   if (nenv == NULL)
     { ea = en; return 0; }
+   environ = nenv;
   }
  environ[en++] = s;
  environ[en] = 0;

--- a/env.c
+++ b/env.c
@@ -55,7 +55,7 @@ static int env_add(s) char *s;
  if (en == ea)
   {
    ea += 30;
-   if (!alloc_re(&environ,(en + 1) * sizeof(char *),(ea + 1) * sizeof(char *)))
+   if (!alloc_re((void**)&environ,(en + 1) * sizeof(char *),(ea + 1) * sizeof(char *)))
     { ea = en; return 0; }
   }
  environ[en++] = s;

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -12,6 +12,7 @@ static int ta_rplus ## _internal (ta *x, unsigned int n, unsigned int pluslen) \
   errno = error_nomem; \
   if (x->field) { \
     unsigned int nnum; \
+    type *nfield; \
     if (__builtin_add_overflow(n, pluslen, &n)) \
       return 0; \
     if (n <= x->a) \
@@ -20,8 +21,10 @@ static int ta_rplus ## _internal (ta *x, unsigned int n, unsigned int pluslen) \
       return 0; \
     if (__builtin_mul_overflow(nnum, sizeof(type), &nlen)) \
       return 0; \
-    if (!alloc_re((void**)&x->field,x->a * sizeof(type),nlen)) \
+    nfield = realloc(x->field, nlen); \
+    if (nfield == NULL) \
       return 0; \
+    x->field = nfield; \
     x->a = nnum; \
     return 1; } \
   x->len = 0; \

--- a/gen_allocdefs.h
+++ b/gen_allocdefs.h
@@ -20,7 +20,7 @@ static int ta_rplus ## _internal (ta *x, unsigned int n, unsigned int pluslen) \
       return 0; \
     if (__builtin_mul_overflow(nnum, sizeof(type), &nlen)) \
       return 0; \
-    if (!alloc_re(&x->field,x->a * sizeof(type),nlen)) \
+    if (!alloc_re((void**)&x->field,x->a * sizeof(type),nlen)) \
       return 0; \
     x->a = nnum; \
     return 1; } \


### PR DESCRIPTION
It is only used at 2 places, and needs overhaul anyway to get rid of compiler warnings. See more rationale in the commit messages.