### PR TITLE
add additional groups for qmail-remote

### DIFF
--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -1,0 +1,49 @@
+name: C CI on OpenBSD
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: OpenBSD-${{ matrix.config.name }}
+    # see https://github.com/vmactions/openbsd-vm: must be macos-12
+    runs-on: macos-12
+    env:
+      CFLAGS: ${{ matrix.config.cflags }}
+      NROFF: ${{ matrix.config.nroff }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+         - {
+           name: "default64",
+           nroff: "nroff",
+           cflags: ""
+         }
+         - {
+           name: "no_obsolete64",
+           nroff: "true",
+           cflags: "-DDEPRECATED_FUNCTIONS_REMOVED"
+         }
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+
+    - name: Test in OpenBSD
+      id: test
+      uses: vmactions/openbsd-vm@v0
+      with:
+        envs: 'CFLAGS NROFF'
+        prepare: |
+          pkg_add check
+        run: |
+          echo "cc -m64 -O2 ${CFLAGS}" > conf-cc
+          echo "cc -m64 -s" > conf-ld
+          make it man NROFF=${NROFF}
+          cd tests
+          make test

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   build:
     name: Solaris-${{ matrix.config.name }}
-    runs-on: macos-10.15
+    # see https://github.com/vmactions/solaris-vm: must be macos-12
+    runs-on: macos-12
     env:
       CFLAGS: ${{ matrix.config.cflags }}
       NROFF: ${{ matrix.config.nroff }}
@@ -32,9 +33,9 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    - name: Test in solaris
+    - name: Test in Solaris
       id: test
       uses: vmactions/solaris-vm@v0
       with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+- 20221115 honor all groups of qmailr user when spawning qmail-rspawn
 - 20221019 code: netstring parsing in qmail-qmtpd & qmail-qmqpd now
            checks that the netstring length is actually a number.
 - 20210122 code: remove register storage class declaration from codebase.

--- a/autobuilds/openbsd.yml
+++ b/autobuilds/openbsd.yml
@@ -1,0 +1,1 @@
+../.github/workflows/openbsd.yml

--- a/prot.c
+++ b/prot.c
@@ -1,12 +1,21 @@
 #include "prot.h"
 
 #include <sys/types.h>
-#include <unistd.h>
 #include <grp.h>
+#include <unistd.h>
 
 int prot_gid(gid_t gid)
 {
   if (setgroups(1,&gid) == -1) return -1;
+
+  return setgid(gid); /* _should_ be redundant, but on some systems it isn't */
+}
+
+int prot_gids(const char *user, gid_t gid)
+{
+  /* member of too many groups */
+  if (initgroups(user, gid) == -1) return -1;
+
   return setgid(gid); /* _should_ be redundant, but on some systems it isn't */
 }
 

--- a/prot.c
+++ b/prot.c
@@ -18,8 +18,3 @@ int prot_gids(const char *user, gid_t gid)
 
   return setgid(gid); /* _should_ be redundant, but on some systems it isn't */
 }
-
-int prot_uid(uid_t uid)
-{
-  return setuid(uid);
-}

--- a/prot.h
+++ b/prot.h
@@ -2,9 +2,10 @@
 #define PROT_H
 
 #include <sys/types.h>
+#include <unistd.h>
 
 extern int prot_gid(gid_t gid);
 extern int prot_gids(const char *user, gid_t gid);
-extern int prot_uid(uid_t uid);
+#define prot_uid(uid) setuid(uid)
 
 #endif

--- a/prot.h
+++ b/prot.h
@@ -1,7 +1,10 @@
 #ifndef PROT_H
 #define PROT_H
 
-extern int prot_gid();
-extern int prot_uid();
+#include <sys/types.h>
+
+extern int prot_gid(gid_t gid);
+extern int prot_gids(const char *user, gid_t gid);
+extern int prot_uid(uid_t uid);
 
 #endif

--- a/qmail-start.c
+++ b/qmail-start.c
@@ -105,6 +105,7 @@ int main(int argc, char **argv)
   switch(fork()) {
     case -1: die();
     case 0:
+      if (prot_gids(auto_userr, auto_gidq) == -1) die();
       if (prot_uid(auto_uidr) == -1) die();
       if (fd_copy(0,pi3[0]) == -1) die();
       if (fd_copy(1,pi4[1]) == -1) die();


### PR DESCRIPTION
The idea is that qmail-remote may read files that other qmail processes may not read, and additionally ones that it may exclusively read without owning them. The intended use case is for DKIM keys (exclusively read) and TLS keys (shared with qmail-smtpd).