### PR TITLE
TARGETS: drop needless auto_uid*.o and auto_gid*.o entries

### DIFF
--- a/TARGETS
+++ b/TARGETS
@@ -138,16 +138,6 @@ cdb_seek.o
 cdb.a
 uid.o
 gid.o
-auto_uida.o
-auto_uidd.o
-auto_uidl.o
-auto_uido.o
-auto_uidp.o
-auto_uidq.o
-auto_uidr.o
-auto_uids.o
-auto_gidn.o
-auto_gidq.o
 qmail-lspawn
 qmail-getpw.o
 auto_break.c


### PR DESCRIPTION
These have only existed in intermediate versions of the "look up uid/gid at runtime" patchset.

Fixes: 580bf26e8a211fdff3ad3083e5e771662a921e3a