### PR TITLE
reintroduce alloc_re()

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
   pkginstall_script:
     - pkg install -y groff pkgconf check
   configure_script:
-    - echo "clang -O2 -Wall -Wshadow -Werror=implicit-function-declaration" > conf-cc
+    - echo "clang -O2 -Wall -Wshadow -Werror=implicit-function-declaration -Werror=deprecated-declarations" > conf-cc
   compile_script:
     - make ${MAKE_FLAGS} it man
   test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   matrix:
     - BUILD_NAME="default"
     - BUILD_NAME="utmp" FORCE_UTMP="1" MAKEFLAGS="-o qtmp.h"
-    - BUILD_NAME="no_catman" AVOID_NROFF="1"
+    - BUILD_NAME="no_catman" AVOID_NROFF="1" EXTRA_CFLAGS="-DDONT_PROVIDE_OBSOLETE"
 compiler:
  - gcc
  - clang
@@ -14,7 +14,7 @@ addons:
     - pkg-config
     - check
 script:
- - echo "${CC} -O2 -Wall -Wshadow -Werror=implicit-function-declaration" > conf-cc
+ - echo "${CC} -O2 -Wall -Wshadow -Werror=implicit-function-declaration -Werror=deprecated-declarations ${EXTRA_CFLAGS}" > conf-cc
  - if [ -n "${FORCE_UTMP}" ]; then cp qtmp.h1 qtmp.h; fi
  - if [ -n "${AVOID_NROFF}" ]; then NROFF=true; export NROFF; fi
  - make ${MAKEFLAGS} it man

--- a/alloc.h
+++ b/alloc.h
@@ -6,4 +6,27 @@
 #define alloc(x) malloc(x)
 #define alloc_free(x) free(x)
 
+/*
+ * In-tree code must not call this deprecated function. It's here because
+ * some external patches still do. We intend to remove it as soon as is
+ * practical.
+ */
+#ifndef DONT_PROVIDE_OBSOLETE
+
+#if defined(__clang__) || defined(__GNUC__)
+#define _deprecated_ __attribute__((deprecated))
+#else
+#define _deprecated_
+#endif
+
+static inline int _deprecated_ alloc_re(void **x, unsigned int m, unsigned int n)
+{
+  void *y = realloc(*x, n);
+  (void)m;
+  if (y != NULL)
+    *x = y;
+  return !!y;
+}
+#endif
+
 #endif


### PR DESCRIPTION
This is used by the large-dns patch, and may be used by others. Add it back in a way that it will not be compiled in our normal build, but a simple compiler define allows external patches to find the needed environment.