### PR TITLE
check presence of struct utimbuf and use it if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -662,6 +662,12 @@ trysgprm.c compile load
 	&& echo \#define HASSIGPROCMASK 1 || exit 0 ) > hassgprm.h
 	rm -f trysgprm.o trysgprm
 
+hasutbuf.h: \
+tryutbuf.c compile
+	( ./compile tryutbuf.c >/dev/null 2>&1 \
+	&& echo \#define HASUTBUF 1 || exit 0 ) > hasutbuf.h
+	rm -f tryutbuf.o
+
 haswaitp.h: \
 trywaitp.c compile load
 	( ( ./compile trywaitp.c && ./load trywaitp ) >/dev/null \
@@ -1429,7 +1435,7 @@ open.h seek.h exit.h lock.h ndelay.h now.h datetime.h getln.h \
 substdio.h alloc.h error.h stralloc.h gen_alloc.h str.h byte.h fmt.h \
 scan.h case.h auto_qmail.h trigger.h newfield.h stralloc.h quote.h \
 qmail.h substdio.h qsutil.h prioq.h datetime.h gen_alloc.h constmap.h \
-fmtqfn.h readsubdir.h direntry.h
+fmtqfn.h readsubdir.h direntry.h hasutbuf.h
 	./compile qmail-send.c
 
 qmail-send.service: \

--- a/TARGETS
+++ b/TARGETS
@@ -26,6 +26,7 @@ getopt.a
 sig_alarm.o
 oflops.h
 hassgprm.h
+hasutbuf.h
 sig_block.o
 hassgact.h
 sig_catch.o

--- a/qmail-send.c
+++ b/qmail-send.c
@@ -1,6 +1,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <utime.h>
+#include "hasutbuf.h"
 #include "readwrite.h"
 #include "sig.h"
 #include "direntry.h"
@@ -450,14 +451,22 @@ void pqfinish()
 {
  int c;
  struct prioq_elt pe;
+#ifdef HASUTBUF
+ struct utimbuf ut[1];
+#else
  time_t ut[2]; /* XXX: more portable than utimbuf, but still worrisome */
+#endif
 
  for (c = 0;c < CHANNELS;++c)
    while (prioq_min(&pqchan[c],&pe))
     {
      prioq_delmin(&pqchan[c]);
      fnmake_chanaddr(pe.id,c);
+#ifdef HASUTBUF
+     ut[0].actime = ut[0].modtime = pe.dt;
+#else
      ut[0] = ut[1] = pe.dt;
+#endif
      if (utime(fn.s,ut) == -1)
        log3("warning: unable to utime ",fn.s,"; message will be retried too soon\n");
     }

--- a/tryutbuf.c
+++ b/tryutbuf.c
@@ -1,0 +1,9 @@
+#include <sys/types.h>
+#include <utime.h>
+
+void foo()
+{
+  struct utimbuf ut;
+  ut.actime = ut.modtime = 42;
+  utime("/dummy", &ut);
+}


### PR DESCRIPTION
This fixes a compiler warning on most platforms:

```
qmail-send.c:471:21: warning: passing argument 2 of ‘utime’ from incompatible pointer type [-Wincompatible-pointer-types]
```