### PR TITLE
qmail-remote: fix warnings about get() being used with wrong pointer signedness

### DIFF
--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -130,9 +130,9 @@ substdio smtpfrom = SUBSTDIO_FDBUF(saferead,-1,smtpfrombuf,sizeof smtpfrombuf);
 
 stralloc smtptext = {0};
 
-void get(ch)
-char *ch;
+static void get(unsigned char *uc)
 {
+  char *ch = (char *)uc;
   substdio_get(&smtpfrom,ch,1);
   if (*ch != '\r')
     if (smtptext.len < HUGESMTPTEXT)


### PR DESCRIPTION
Became visible when building with clang.