### PR TITLE
qmail-smtpd: allow [] to appear in received lines

### DIFF
--- a/received.c
+++ b/received.c
@@ -18,6 +18,8 @@ static int issafe(ch) char ch;
   if ((ch >= 'a') && (ch <= 'z')) return 1;
   if ((ch >= 'A') && (ch <= 'Z')) return 1;
   if ((ch >= '0') && (ch <= '9')) return 1;
+  if (ch == '[') return 1;
+  if (ch == ']') return 1;
   return 0;
 }
 


### PR DESCRIPTION
A client that can't find out the hostname should send "[ip.ad.dr.ess]" as HELO or EHLO string. But since the square brackets were considered unsafe qmail-smtpd mangled them to ? in the Received line actually written to the mail.