### PR TITLE
always include the own header first in all C files

### DIFF
--- a/cdbmss.c
+++ b/cdbmss.c
@@ -1,7 +1,8 @@
+#include "cdbmss.h"
+
 #include "readwrite.h"
 #include "seek.h"
 #include "alloc.h"
-#include "cdbmss.h"
 
 int cdbmss_start(c,fd)
 struct cdbmss *c;

--- a/coe.c
+++ b/coe.c
@@ -1,5 +1,6 @@
-#include <fcntl.h>
 #include "coe.h"
+
+#include <fcntl.h>
 
 int coe(fd)
 int fd;

--- a/commands.c
+++ b/commands.c
@@ -1,4 +1,5 @@
 #include "commands.h"
+
 #include "substdio.h"
 #include "stralloc.h"
 #include "str.h"

--- a/constmap.c
+++ b/constmap.c
@@ -1,4 +1,5 @@
 #include "constmap.h"
+
 #include "alloc.h"
 #include "case.h"
 

--- a/control.c
+++ b/control.c
@@ -1,10 +1,11 @@
+#include "control.h"
+
 #include "readwrite.h"
 #include "open.h"
 #include "getln.h"
 #include "stralloc.h"
 #include "substdio.h"
 #include "error.h"
-#include "control.h"
 #include "alloc.h"
 #include "scan.h"
 

--- a/date822fmt.c
+++ b/date822fmt.c
@@ -1,6 +1,7 @@
+#include "date822fmt.h"
+
 #include "datetime.h"
 #include "fmt.h"
-#include "date822fmt.h"
 
 static char *montab[12] = {
 "Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"

--- a/dns.c
+++ b/dns.c
@@ -1,3 +1,5 @@
+#include "dns.h"
+
 #include <stdio.h>
 #include <netdb.h>
 #include <sys/types.h>
@@ -16,7 +18,6 @@ extern int res_search();
 #include "alloc.h"
 #include "str.h"
 #include "stralloc.h"
-#include "dns.h"
 #include "case.h"
 
 static unsigned short getshort(c) unsigned char *c;

--- a/dnsdoe.c
+++ b/dnsdoe.c
@@ -1,8 +1,9 @@
+#include "dnsdoe.h"
+
 #include "substdio.h"
 #include "subfd.h"
 #include "exit.h"
 #include "dns.h"
-#include "dnsdoe.h"
 
 void dnsdoe(r)
 int r;

--- a/env.c
+++ b/env.c
@@ -6,9 +6,10 @@ Requires environ.
 No known patent problems.
 */
 
+#include "env.h"
+
 #include "str.h"
 #include "alloc.h"
-#include "env.h"
 
 #include <string.h>
 

--- a/fifo.c
+++ b/fifo.c
@@ -1,7 +1,8 @@
+#include "fifo.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "hasmkffo.h"
-#include "fifo.h"
 
 #ifdef HASMKFIFO
 int fifo_make(fn,mode) char *fn; int mode; { return mkfifo(fn,mode); }

--- a/fmtqfn.c
+++ b/fmtqfn.c
@@ -1,4 +1,5 @@
 #include "fmtqfn.h"
+
 #include "fmt.h"
 #include "auto_split.h"
 

--- a/getln.c
+++ b/getln.c
@@ -1,7 +1,8 @@
+#include "getln.h"
+
 #include "substdio.h"
 #include "byte.h"
 #include "stralloc.h"
-#include "getln.h"
 
 int getln(ss,sa,match,sep)
 register substdio *ss;

--- a/gfrom.c
+++ b/gfrom.c
@@ -1,5 +1,6 @@
-#include "str.h"
 #include "gfrom.h"
+
+#include "str.h"
 
 int gfrom(s,len)
 char *s;

--- a/headerbody.c
+++ b/headerbody.c
@@ -1,8 +1,9 @@
+#include "headerbody.h"
+
 #include "stralloc.h"
 #include "substdio.h"
 #include "getln.h"
 #include "hfield.h"
-#include "headerbody.h"
 
 static int getsa(ss,sa,match)
 substdio *ss;

--- a/hier.c
+++ b/hier.c
@@ -1,10 +1,11 @@
+#include "hier.h"
+
 #include <sys/types.h>
 #include "auto_qmail.h"
 #include "auto_split.h"
 #include "auto_uids.h"
 #include "fmt.h"
 #include "fifo.h"
-#include "hier.h"
 
 char buf[100 + FMT_ULONG];
 

--- a/ip.c
+++ b/ip.c
@@ -1,6 +1,7 @@
+#include "ip.h"
+
 #include "fmt.h"
 #include "scan.h"
-#include "ip.h"
 
 unsigned int ip_fmt(s,ip)
 char *s;

--- a/ipalloc.c
+++ b/ipalloc.c
@@ -1,6 +1,7 @@
+#include "ipalloc.h"
+
 #include "gen_allocdefs.h"
 #include "ip.h"
-#include "ipalloc.h"
 
 GEN_ALLOC_readyplus(ipalloc,struct ip_mx,ix,len,a,10,ipalloc_readyplus)
 GEN_ALLOC_append(ipalloc,struct ip_mx,ix,len,a,10,ipalloc_readyplus,ipalloc_append)

--- a/ipme.c
+++ b/ipme.c
@@ -1,3 +1,5 @@
+#include "ipme.h"
+
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/time.h>
@@ -14,7 +16,6 @@
 #include "ip.h"
 #include "ipalloc.h"
 #include "stralloc.h"
-#include "ipme.h"
 
 static int ipmeok = 0;
 ipalloc ipme = {0};

--- a/maildir.c
+++ b/maildir.c
@@ -1,3 +1,5 @@
+#include "maildir.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -8,7 +10,6 @@
 #include "datetime.h"
 #include "now.h"
 #include "str.h"
-#include "maildir.h"
 
 struct strerr maildir_chdir_err;
 struct strerr maildir_scan_err;

--- a/myctime.c
+++ b/myctime.c
@@ -1,6 +1,7 @@
+#include "myctime.h"
+
 #include "datetime.h"
 #include "fmt.h"
-#include "myctime.h"
 
 static char *daytab[7] = {
 "Sun","Mon","Tue","Wed","Thu","Fri","Sat"

--- a/ndelay.c
+++ b/ndelay.c
@@ -1,6 +1,7 @@
+#include "ndelay.h"
+
 #include <sys/types.h>
 #include <fcntl.h>
-#include "ndelay.h"
 
 #ifndef O_NONBLOCK
 #define O_NONBLOCK O_NDELAY

--- a/newfield.c
+++ b/newfield.c
@@ -1,9 +1,10 @@
+#include "newfield.h"
+
 #include <unistd.h>
 #include "fmt.h"
 #include "datetime.h"
 #include "stralloc.h"
 #include "date822fmt.h"
-#include "newfield.h"
 
 /* "Date: 26 Sep 1995 04:46:53 -0000\n" */
 stralloc newfield_date = {0};

--- a/prioq.c
+++ b/prioq.c
@@ -1,5 +1,6 @@
-#include "gen_allocdefs.h"
 #include "prioq.h"
+
+#include "gen_allocdefs.h"
 
 GEN_ALLOC_readyplus(prioq,struct prioq_elt,p,len,a,100,prioq_readyplus)
 

--- a/prot.c
+++ b/prot.c
@@ -1,7 +1,8 @@
+#include "prot.h"
+
 #include <sys/types.h>
 #include <unistd.h>
 #include <grp.h>
-#include "prot.h"
 
 int prot_gid(gid_t gid)
 {

--- a/qmail.c
+++ b/qmail.c
@@ -1,10 +1,11 @@
+#include "qmail.h"
+
 #include "substdio.h"
 #include "readwrite.h"
 #include "wait.h"
 #include "exit.h"
 #include "fork.h"
 #include "fd.h"
-#include "qmail.h"
 #include "auto_qmail.h"
 #include "env.h"
 

--- a/qsutil.c
+++ b/qsutil.c
@@ -1,7 +1,8 @@
+#include "qsutil.h"
+
 #include "stralloc.h"
 #include "readwrite.h"
 #include "substdio.h"
-#include "qsutil.h"
 
 static stralloc foo = {0};
 

--- a/quote.c
+++ b/quote.c
@@ -1,8 +1,9 @@
+#include "quote.h"
+
 #include "error.h"
 #include "oflops.h"
 #include "stralloc.h"
 #include "str.h"
-#include "quote.h"
 
 /*
 quote() encodes a box as per rfc 821 and rfc 822,

--- a/rcpthosts.c
+++ b/rcpthosts.c
@@ -1,3 +1,5 @@
+#include "rcpthosts.h"
+
 #include "case.h"
 #include "cdb.h"
 #include "byte.h"
@@ -6,7 +8,6 @@
 #include "control.h"
 #include "constmap.h"
 #include "stralloc.h"
-#include "rcpthosts.h"
 
 static int flagrh = 0;
 static stralloc rh = {0};

--- a/readsubdir.c
+++ b/readsubdir.c
@@ -1,4 +1,5 @@
 #include "readsubdir.h"
+
 #include "fmt.h"
 #include "scan.h"
 #include "str.h"

--- a/received.c
+++ b/received.c
@@ -1,9 +1,10 @@
+#include "received.h"
+
 #include "fmt.h"
 #include "qmail.h"
 #include "now.h"
 #include "datetime.h"
 #include "date822fmt.h"
-#include "received.h"
 
 static int issafe(ch) char ch;
 {

--- a/remoteinfo.c
+++ b/remoteinfo.c
@@ -1,3 +1,5 @@
+#include "remoteinfo.h"
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -10,7 +12,6 @@
 #include "timeoutconn.h"
 #include "timeoutread.h"
 #include "timeoutwrite.h"
-#include "remoteinfo.h"
 
 static char line[999];
 static int t;

--- a/sgetopt.c
+++ b/sgetopt.c
@@ -9,10 +9,11 @@ No known patent problems.
 Documentation in sgetopt.3.
 */
 
-#include "substdio.h"
-#include "subfd.h"
 #define SGETOPTNOSHORT
 #include "sgetopt.h"
+
+#include "substdio.h"
+#include "subfd.h"
 #define SUBGETOPTNOSHORT
 #include "subgetopt.h"
 

--- a/slurpclose.c
+++ b/slurpclose.c
@@ -1,6 +1,7 @@
+#include "slurpclose.h"
+
 #include "stralloc.h"
 #include "readwrite.h"
-#include "slurpclose.h"
 #include "error.h"
 
 int slurpclose(fd,sa,bufsize)

--- a/spawn.c
+++ b/spawn.c
@@ -1,6 +1,7 @@
+#include "spawn.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "spawn.h"
 #include "sig.h"
 #include "wait.h"
 #include "substdio.h"

--- a/tcpto.c
+++ b/tcpto.c
@@ -1,4 +1,5 @@
 #include "tcpto.h"
+
 #include "open.h"
 #include "lock.h"
 #include "seek.h"

--- a/timeoutconn.c
+++ b/timeoutconn.c
@@ -1,3 +1,5 @@
+#include "timeoutconn.h"
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -8,7 +10,6 @@
 #include "readwrite.h"
 #include "ip.h"
 #include "byte.h"
-#include "timeoutconn.h"
 
 int timeoutconn(s,ip,port,timeout)
 int s;

--- a/timeoutread.c
+++ b/timeoutread.c
@@ -1,4 +1,5 @@
 #include "timeoutread.h"
+
 #include "select.h"
 #include "error.h"
 #include "readwrite.h"

--- a/timeoutwrite.c
+++ b/timeoutwrite.c
@@ -1,4 +1,5 @@
 #include "timeoutwrite.h"
+
 #include "select.h"
 #include "error.h"
 #include "readwrite.h"

--- a/token822.c
+++ b/token822.c
@@ -1,6 +1,7 @@
+#include "token822.h"
+
 #include "stralloc.h"
 #include "str.h"
-#include "token822.h"
 #include "gen_allocdefs.h"
 
 static struct token822 comma = { TOKEN822_COMMA };

--- a/trigger.c
+++ b/trigger.c
@@ -1,7 +1,8 @@
+#include "trigger.h"
+
 #include <unistd.h>
 #include "select.h"
 #include "open.h"
-#include "trigger.h"
 #include "hasnpbg1.h"
 
 static int fd = -1;

--- a/triggerpull.c
+++ b/triggerpull.c
@@ -1,7 +1,8 @@
+#include "triggerpull.h"
+
 #include <unistd.h>
 #include "ndelay.h"
 #include "open.h"
-#include "triggerpull.h"
 
 void triggerpull()
 {


### PR DESCRIPTION
The idea is that the compiler will immediately error out if the header is not self contained, usually because of incomplete forward declarations in such headers.