### PR TITLE
Fix 17 warnings from -Wparentheses.

### DIFF
--- a/auto-str.c
+++ b/auto-str.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
   puts(name);
   puts("[] = \"\\\n");
 
-  while (ch = *value++) {
+  while ((ch = *value++)) {
     if (is_legible(ch)) {
       if (substdio_put(&ss1, &ch, 1) == -1)
         _exit(111);

--- a/case_lowers.c
+++ b/case_lowers.c
@@ -4,7 +4,7 @@ void case_lowers(s)
 char *s;
 {
   unsigned char x;
-  while (x = *s) {
+  while ((x = *s)) {
     x -= 'A';
     if (x <= 'Z' - 'A') *s = x + 'a';
     ++s;

--- a/envread.c
+++ b/envread.c
@@ -9,7 +9,7 @@ char *s;
   char *envi;
  
   slen = str_len(s);
-  for (i = 0;envi = environ[i];++i)
+  for (i = 0;(envi = environ[i]);++i)
     if ((!str_diffn(s,envi,slen)) && (envi[slen] == '='))
       return envi + slen + 1;
   return 0;

--- a/fmt_str.c
+++ b/fmt_str.c
@@ -5,7 +5,7 @@ unsigned int fmt_str(char *s, char *t)
   register unsigned int len;
   char ch;
   len = 0;
-  if (s) { while (ch = t[len]) s[len++] = ch; }
+  if (s) { while ((ch = t[len])) s[len++] = ch; }
   else while (t[len]) len++;
   return len;
 }

--- a/hfield.c
+++ b/hfield.c
@@ -41,7 +41,7 @@ char *t;
  int i;
  char ch;
 
- for (i = 0;ch = t[i];++i)
+ for (i = 0;(ch = t[i]);++i)
   {
    if (i >= len) return 0;
    if (ch != s[i])
@@ -67,7 +67,7 @@ int len;
  int i;
  char *t;
 
- for (i = 1;t = hname[i];++i)
+ for (i = 1;(t = hname[i]);++i)
    if (hmatch(s,len,t))
      return i;
  return 0;

--- a/maildir.c
+++ b/maildir.c
@@ -37,7 +37,7 @@ stralloc *tmpname;
  dir = opendir("tmp");
  if (!dir) return;
 
- while (d = readdir(dir))
+ while ((d = readdir(dir)))
   {
    if (d->d_name[0] == '.') continue;
    if (!stralloc_copys(tmpname,"tmp/")) break;
@@ -66,7 +66,7 @@ datetime_sec time;
  if (!dir)
    STRERR_SYS3(-1,maildir_scan_err,"unable to scan $MAILDIR/",subdir,": ")
 
- while (d = readdir(dir))
+ while ((d = readdir(dir)))
   {
    if (d->d_name[0] == '.') continue;
    pos = filenames->len;

--- a/qmail-clean.c
+++ b/qmail-clean.c
@@ -32,7 +32,7 @@ void cleanuppid()
  time = now();
  dir = opendir("pid");
  if (!dir) return;
- while (d = readdir(dir))
+ while ((d = readdir(dir)))
   {
    if (str_equal(d->d_name,".")) continue;
    if (str_equal(d->d_name,"..")) continue;

--- a/qmail-qread.c
+++ b/qmail-qread.c
@@ -118,7 +118,7 @@ int main(void)
  if (chdir("queue") == -1) die_chdir();
  readsubdir_init(&rs,"info",die_opendir);
 
- while (x = readsubdir_next(&rs,&id))
+ while ((x = readsubdir_next(&rs,&id)))
    if (x > 0)
     {
      fmtqfn(fnmess,"mess/",id,1);

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -343,7 +343,7 @@ int main(int argc, char **argv)
   relayhost = 0;
   for (i = 0;i <= host.len;++i)
     if ((i == 0) || (i == host.len) || (host.s[i] == '.'))
-      if (relayhost = constmap(&maproutes,host.s + i,host.len - i))
+      if ((relayhost = constmap(&maproutes,host.s + i,host.len - i)))
         break;
   if (relayhost && !*relayhost) relayhost = 0;
  

--- a/qmail-send.c
+++ b/qmail-send.c
@@ -148,7 +148,7 @@ char *recip;
 
   for (i = 0;i <= addr.len;++i)
     if (!i || (i == at + 1) || (i == addr.len) || ((i > at) && (addr.s[i] == '.')))
-      if (x = constmap(&mapvdoms,addr.s + i,addr.len - i)) {
+      if ((x = constmap(&mapvdoms,addr.s + i,addr.len - i))) {
         if (!*x) break;
         if (!stralloc_cats(&rwline,x)) return 0;
         if (!stralloc_cats(&rwline,"-")) return 0;
@@ -441,7 +441,7 @@ void pqstart()
 
  readsubdir_init(&rs,"info",pausedir);
 
- while (x = readsubdir_next(&rs,&id))
+ while ((x = readsubdir_next(&rs,&id)))
    if (x > 0)
      pqadd(id);
 }
@@ -584,7 +584,7 @@ char *recip;
 
  for (i = 0;i <= domainlen;++i)
    if ((i == 0) || (i == domainlen) || (domain[i] == '.'))
-     if (prepend = constmap(&mapvdoms,domain + i,domainlen - i))
+     if ((prepend = constmap(&mapvdoms,domain + i,domainlen - i)))
       {
        if (!*prepend) break;
        i = str_len(prepend);

--- a/qmail-showctl.c
+++ b/qmail-showctl.c
@@ -288,7 +288,7 @@ int main(void)
   do_int("timeoutsmtpd","1200","SMTP server data timeout is "," seconds");
   do_lst("virtualdomains","No virtual domains.","Virtual domain: ","");
 
-  while (d = readdir(dir)) {
+  while ((d = readdir(dir))) {
     if (str_equal(d->d_name,".")) continue;
     if (str_equal(d->d_name,"..")) continue;
     if (str_equal(d->d_name,"bouncefrom")) continue;

--- a/qmail-smtpd.c
+++ b/qmail-smtpd.c
@@ -165,7 +165,7 @@ char *arg;
   if (!stralloc_copys(&addr,"")) die_nomem();
   flagesc = 0;
   flagquoted = 0;
-  for (i = 0;ch = arg[i];++i) { /* copy arg to addr, stripping quotes */
+  for (i = 0;(ch = arg[i]);++i) { /* copy arg to addr, stripping quotes */
     if (flagesc) {
       if (!stralloc_append(&addr,&ch)) die_nomem();
       flagesc = 0;

--- a/received.c
+++ b/received.c
@@ -28,7 +28,7 @@ struct qmail *qqt;
 char *s;
 {
   char ch;
-  while (ch = *s++) {
+  while ((ch = *s++)) {
     if (!issafe(ch)) ch = '?';
     qmail_put(qqt,&ch,1);
   }


### PR DESCRIPTION
The clang warning message says "using the result of an assignment as a
condition without parentheses". Parenthesize these assignments, because
their being also used as conditions is intentional.

This modifies qmail-remote:main() and qmail-smtpd:addrparse(), neither
of which are likely to affect users' patches.