### PR TITLE
Fix 5 warnings from -Wdangling-else.

### DIFF
--- a/qmail-getpw.c
+++ b/qmail-getpw.c
@@ -37,7 +37,7 @@ int userext()
 	pw = getpwnam(username);
 	if (errno == error_txtbsy) _exit(QLX_SYS);
 	if (pw)
-	  if (pw->pw_uid)
+	  if (pw->pw_uid) {
 	    if (stat(pw->pw_dir,&st) == 0) {
 	      if (st.st_uid == pw->pw_uid) {
 		dash = "";
@@ -47,6 +47,7 @@ int userext()
 	    }
 	    else
 	      if (error_temp(errno)) _exit(QLX_NFS);
+	  }
       }
     if (extension == local) return 0;
     --extension;

--- a/qmail-inject.c
+++ b/qmail-inject.c
@@ -106,7 +106,7 @@ void exitnicely()
      if (!stralloc_0(&reciplist.sa[i])) die_nomem();
      qmail_to(&qqt,reciplist.sa[i].s);
     }
-   if (flagrh)
+   if (flagrh) {
      if (flagresent)
        for (i = 0;i < hrrlist.len;++i)
 	{
@@ -119,9 +119,10 @@ void exitnicely()
          if (!stralloc_0(&hrlist.sa[i])) die_nomem();
 	 qmail_to(&qqt,hrlist.sa[i].s);
 	}
+   }
 
    qqx = qmail_close(&qqt);
-   if (*qqx)
+   if (*qqx) {
      if (*qqx == 'D') {
        substdio_puts(subfderr,"qmail-inject: fatal: ");
        substdio_puts(subfderr,qqx + 1);
@@ -136,6 +137,7 @@ void exitnicely()
        substdio_flush(subfderr);
        temp();
      }
+   }
   }
 
  _exit(0);

--- a/qmail-local.c
+++ b/qmail-local.c
@@ -320,11 +320,12 @@ void checkhome()
    strerr_die3x(111,"Unable to stat home directory: ",error_str(errno),". (#4.3.0)");
  if (st.st_mode & auto_patrn)
    strerr_die1x(111,"Uh-oh: home directory is writable. (#4.7.0)");
- if (st.st_mode & 01000)
+ if (st.st_mode & 01000) {
    if (flagdoit)
      strerr_die1x(111,"Home directory is sticky: user is editing his .qmail file. (#4.2.1)");
    else
      strerr_warn1("Warning: home directory is sticky.",0);
+ }
 }
 
 int qmeox(dashowner)

--- a/qreceipt.c
+++ b/qreceipt.c
@@ -91,9 +91,10 @@ following address: ");
  qmail_to(&qqt,returnpath);
  qqx = qmail_close(&qqt);
 
- if (*qqx)
+ if (*qqx) {
    if (*qqx == 'D') die_qqperm();
    else die_qqtemp();
+ }
 }
 
 stralloc hfbuf = {0};


### PR DESCRIPTION
The clang warning message says "add explicit braces to avoid dangling
else". Brace ourselves.

This modifies qmail-inject:exitnicely() and qmail-local:checkhome(),
neither of which are likely to affect users' patches.