### PR TITLE
Fix 3 warnings from -Wpointer-sign.

### DIFF
--- a/tcp-env.c
+++ b/tcp-env.c
@@ -32,7 +32,7 @@ char temp[IPFMT + FMT_ULONG];
 
 int main(int argc, char **argv)
 {
- int dummy;
+ unsigned int dummy;
  char *proto;
  int opt;
  int flagremoteinfo;

--- a/timeoutconn.c
+++ b/timeoutconn.c
@@ -44,7 +44,7 @@ int timeout;
  
   if (select(s + 1,NULL,&wfds,NULL,&tv) == -1) return -1;
   if (FD_ISSET(s,&wfds)) {
-    int dummy;
+    unsigned int dummy;
     dummy = sizeof(sin);
     if (getpeername(s,(struct sockaddr *) &sin,&dummy) == -1) {
       read(s,&ch,1);


### PR DESCRIPTION
The clang warning message says "passing 'int *' to parameter of type
'socklen_t *' (aka 'unsigned int *') converts between pointers to
integer types with different sign". Indeed, the passed values are from
sizeof(). Make them unsigned.