### PR TITLE
Fix 2 warnings from -Wincompatible-library-redeclaration.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,7 +26,7 @@ jobs:
            name: gcc-no_obsolete,
            cc: gcc,
            nroff: nroff,
-           cflags: "-DDONT_PROVIDE_OBSOLETE"
+           cflags: "-DDEPRECATED_FUNCTIONS_REMOVED"
          }
          - {
            name: clang-default,
@@ -38,7 +38,7 @@ jobs:
            name: clang-no_obsolete,
            cc: clang,
            nroff: true,
-           cflags: "-DDONT_PROVIDE_OBSOLETE"
+           cflags: "-DDEPRECATED_FUNCTIONS_REMOVED"
          }
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   matrix:
     - BUILD_NAME="default"
     - BUILD_NAME="utmp" FORCE_UTMP="1" MAKEFLAGS="-o qtmp.h"
-    - BUILD_NAME="no_catman" AVOID_NROFF="1" EXTRA_CFLAGS="-DDONT_PROVIDE_OBSOLETE"
+    - BUILD_NAME="no_catman" AVOID_NROFF="1" EXTRA_CFLAGS="-DDEPRECATED_FUNCTIONS_REMOVED"
 compiler:
  - gcc
  - clang

--- a/alloc.h
+++ b/alloc.h
@@ -6,19 +6,8 @@
 #define alloc(x) malloc(x)
 #define alloc_free(x) free(x)
 
-/*
- * In-tree code must not call this deprecated function. It's here because
- * some external patches still do. We intend to remove it as soon as is
- * practical.
- */
-#ifndef DONT_PROVIDE_OBSOLETE
-
-#if defined(__clang__) || defined(__GNUC__)
-#define _deprecated_ __attribute__((deprecated))
-#else
-#define _deprecated_
-#endif
-
+#include "deprecated.h"
+#ifdef DEPRECATED_FUNCTIONS_AVAILABLE
 static inline int _deprecated_ alloc_re(void **x, unsigned int m, unsigned int n)
 {
   void *y = realloc(*x, n);

--- a/deprecated.h
+++ b/deprecated.h
@@ -1,0 +1,25 @@
+#ifndef DEPRECATED_H
+#define DEPRECATED_H
+
+/*
+ * We sometimes decide certain functions should no longer be called.
+ * If valuable external patches still call them, we wait to delete them
+ * until those patches stop being valuable.
+ *
+ * In the meantime, we
+ *
+ * 1. Mark these functions deprecated, so compilers will warn people
+ * 2. Optionally define them out of existence, mainly for developer builds
+ */
+
+#ifndef DEPRECATED_FUNCTIONS_REMOVED
+#define DEPRECATED_FUNCTIONS_AVAILABLE
+#endif
+
+#if defined(__clang__) || defined(__GNUC__)
+#define _deprecated_ __attribute__((deprecated))
+#else
+#define _deprecated_
+#endif
+
+#endif

--- a/qmail-send.c
+++ b/qmail-send.c
@@ -752,7 +752,7 @@ I tried to deliver a bounce message to this address, but the bounce bounced!\n\
     { log1("warning: trouble injecting bounce message, will try later\n"); return 0; }
 
    strnum2[fmt_ulong(strnum2,id)] = 0;
-   log2("bounce msg ",strnum2);
+   qslog2("bounce msg ",strnum2);
    strnum2[fmt_ulong(strnum2,qp)] = 0;
    log3(" qp ",strnum2,"\n");
   }
@@ -792,8 +792,8 @@ void del_status()
   for (c = 0;c < CHANNELS;++c) {
     strnum2[fmt_ulong(strnum2,(unsigned long) concurrencyused[c])] = 0;
     strnum3[fmt_ulong(strnum3,(unsigned long) concurrency[c])] = 0;
-    log2(chanstatusmsg[c],strnum2);
-    log2("/",strnum3);
+    qslog2(chanstatusmsg[c],strnum2);
+    qslog2("/",strnum3);
   }
   if (flagexitasap) log1(" exitasap");
   log1("\n");
@@ -857,7 +857,7 @@ char *recip;
 
  strnum2[fmt_ulong(strnum2,d[c][i].delid)] = 0;
  strnum3[fmt_ulong(strnum3,jo[j].id)] = 0;
- log2("starting delivery ",strnum2);
+ qslog2("starting delivery ",strnum2);
  log3(": msg ",strnum3,tochan[c]);
  logsafe(recip);
  log1("\n");
@@ -1350,14 +1350,14 @@ fd_set *rfds;
 	 fnmake_info(id);
          log3("warning: trouble writing to ",fn.s,"\n"); goto fail;
 	}
-       log2("info msg ",strnum3);
+       qslog2("info msg ",strnum3);
        strnum2[fmt_ulong(strnum2,(unsigned long) st.st_size)] = 0;
-       log2(": bytes ",strnum2);
+       qslog2(": bytes ",strnum2);
        log1(" from <"); logsafe(todoline.s + 1);
        strnum2[fmt_ulong(strnum2,pid)] = 0;
-       log2("> qp ",strnum2);
+       qslog2("> qp ",strnum2);
        strnum2[fmt_ulong(strnum2,uid)] = 0;
-       log2(" uid ",strnum2);
+       qslog2(" uid ",strnum2);
        log1("\n");
        break;
      case 'T':

--- a/qsutil.c
+++ b/qsutil.c
@@ -12,7 +12,7 @@ void logsa(sa) stralloc *sa; {
  substdio_putflush(&sserr,sa->s,sa->len); }
 void log1(s1) char *s1; {
  substdio_putsflush(&sserr,s1); }
-void log2(s1,s2) char *s1; char *s2; {
+void qslog2(char *s1, char *s2) {
  substdio_putsflush(&sserr,s1);
  substdio_putsflush(&sserr,s2); }
 void log3(s1,s2,s3) char *s1; char *s2; char *s3; {

--- a/qsutil.h
+++ b/qsutil.h
@@ -2,7 +2,16 @@
 #define QSUTIL_H
 
 extern void log1();
-extern void log2();
+extern void qslog2(char *, char *);
+
+#include "deprecated.h"
+#ifdef DEPRECATED_FUNCTIONS_AVAILABLE
+static inline void _deprecated_ log2(char *s1, char *s2)
+{
+  qslog2(s1,s2);
+}
+#endif
+
 extern void log3();
 extern void logsa();
 extern void nomem();


### PR DESCRIPTION
The clang warning message says "incompatible redeclaration of library
function 'log2'". Call ours qslog2() instead, providing a compatibility
define for the old name in case patches need it.