### PR TITLE
Define CODEOWNERS with our default reviewers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DerDakon @josuah @leahneukirchen @mbhangui @schmonz


### PR DESCRIPTION
From <https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-file-location>:

"Code owners are automatically requested for review when someone opens a
pull request that modifies code that they own."

I've not listed everyone in our GitHub org, just the folks who are
usually doing the reviewing (and from whom I usually request reviews).
No exclusion is intended, just sensible defaults. We can always manually
request additional reviewers on any given PR, and anyone who wants to
get more generally involved can of course add themselves here.

Once merged, we need to enable "Require review from Code Owners" in the [repo settings](https://github.com/notqmail/notqmail/settings/branch_protection_rules/5905138).