### PR TITLE
Fix CodeQL cpp/integer-multiplication-cast-to-long.

### DIFF
--- a/qmail-send.c
+++ b/qmail-send.c
@@ -1043,7 +1043,7 @@ datetime_sec nextretry(birth,c)
 datetime_sec birth;
 int c;
 {
- int n;
+ datetime_sec n;
 
  if (birth > recent) n = 0;
  else n = squareroot(recent - birth); /* no need to add fuzz to recent */


### PR DESCRIPTION
(Seen under the [project's "code scanning alerts"](https://github.com/notqmail/notqmail/security/code-scanning).)

"Multiplication result may overflow 'int' before it is converted to 'long'."

Recommendation: "Use a cast to ensure that the multiplication is done
using the larger integer type to avoid overflow."