### PR TITLE
EAI support for qmail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1348,16 +1348,35 @@ alloc.h substdio.h datetime.h now.h datetime.h triggerpull.h extra.h \
 uidgid.h auto_qmail.h auto_uids.h auto_users.h date822fmt.h fmtqfn.h
 	./compile qmail-queue.c
 
+hassmtputf8.h: \
+tryidn2.c compile load conf-smtputf8
+	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
+		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
+	&& echo \#define SMTPUTF8 1 || echo "WARNING!!! Not compiled with -DSMTPUTF8" 1<&2) > hassmtputf8.h
+	rm -f tryidn2.o tryidn2
+
+idn2.lib: \
+tryidn2.c compile load conf-smtputf8
+	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
+		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
+	&& echo "-lidn2" || echo "WARNING!!! Not linked with libidn2" 1>&2) > idn2.lib
+	rm -f tryidn2.o tryidn2
+
+utf8read.o: \
+compile utf8read.c hassmtputf8.h stralloc.h case.h substdio.h subfd.h
+	./compile utf8read.c
+
 qmail-remote: \
 load qmail-remote.o control.o constmap.o timeoutread.o timeoutwrite.o \
-timeoutconn.o tcpto.o dns.o ip.o ipalloc.o ipme.o quote.o \
-ndelay.a case.a sig.a open.a lock.a getln.a stralloc.a \
-substdio.a error.a str.a fs.a auto_qmail.o dns.lib socket.lib
+timeoutconn.o tcpto.o dns.o ip.o ipalloc.o ipme.o quote.o envread.o \
+utf8read.o ndelay.a case.a sig.a open.a lock.a getln.a stralloc.a \
+substdio.a error.a str.a fs.a auto_qmail.o dns.lib socket.lib \
+idn2.lib
 	./load qmail-remote control.o constmap.o timeoutread.o \
-	timeoutwrite.o timeoutconn.o tcpto.o dns.o ip.o \
+	timeoutwrite.o timeoutconn.o tcpto.o dns.o ip.o utf8read.o \
 	ipalloc.o ipme.o quote.o ndelay.a case.a sig.a open.a \
-	lock.a getln.a stralloc.a substdio.a error.a \
-	str.a fs.a auto_qmail.o  `cat dns.lib` `cat socket.lib`
+	envread.o lock.a getln.a stralloc.a substdio.a error.a \
+	str.a fs.a auto_qmail.o  `cat dns.lib socket.lib idn2.lib`
 
 qmail-remote.0: \
 qmail-remote.8
@@ -1368,7 +1387,7 @@ subfd.h substdio.h scan.h case.h error.h auto_qmail.h control.h dns.h \
 alloc.h quote.h ip.h ipalloc.h ip.h gen_alloc.h ipme.h ip.h ipalloc.h \
 gen_alloc.h gen_allocdefs.h str.h now.h datetime.h exit.h constmap.h \
 tcpto.h readwrite.h timeoutconn.h timeoutread.h timeoutwrite.h oflops.h \
-error.h
+error.h hassmtputf8.h utf8read.h env.h
 	./compile qmail-remote.c
 
 qmail-rspawn: \

--- a/TARGETS
+++ b/TARGETS
@@ -371,3 +371,7 @@ forgeries.0
 setup
 qtmp.h
 qmail-send.service
+trysmtputf8
+idn2.lib
+hassmtputf8.h
+utf8read.o

--- a/conf-smtputf8
+++ b/conf-smtputf8
@@ -1,0 +1,1 @@
+-DSMTPUTF8

--- a/qmail-remote.8
+++ b/qmail-remote.8
@@ -47,6 +47,14 @@ arguments to
 The envelope sender address is listed as
 .I sender\fP.
 
+If the environment variable UTF8 is defined,
+.B qmail-remote
+will respect SMTPUTF8 and EAI addresses. If message is utf8,
+.B qmail-remote
+will use idn2_lookup_u8(3) to perform IDNA2008 lookup string conversion
+on
+.IR host .
+
 Note that
 .B qmail-remote
 does not take options

--- a/qmail-smtpd.8
+++ b/qmail-smtpd.8
@@ -14,6 +14,14 @@ must be supplied several environment variables;
 see
 .BR tcp-environ(5) .
 
+If the environment variable
+.B UTF8
+is non-empty
+.B qmail-smtpd
+offers RFC 5336 SMTP Email Address Internationalization support and will advertize the
+capability in the EHLO greeting. Since qmail-smtpd is 8 bit clean, setting of UTF8 has no real
+consequences except for displaying this setting in the received headers as \fBUTF8(E)SMTP\fR.
+
 .B qmail-smtpd
 is responsible for counting hops.
 It rejects any message with 100 or more 
@@ -35,6 +43,7 @@ see
 .B qmail-smtpd
 accepts messages that contain long lines or non-ASCII characters,
 even though such messages violate the SMTP protocol.
+
 .SH "CONTROL FILES"
 .TP 5
 .I badmailfrom

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,4 +1,9 @@
 *.o
 unittest_blast
 unittest_stralloc
+unittest_utf8read
+unittest_prioq
 blast.c
+get_capability.c
+smtpcode.c
+mailfrom_parms.c

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,10 +9,12 @@ default: it
 
 .PHONY: clean default it test
 
-TESTBINS = unittest_stralloc unittest_blast unittest_prioq
+TESTBINS = unittest_stralloc unittest_blast unittest_prioq \
+		   unittest_utf8read
 
 clean:
-	rm -f $(TESTBINS) *.o blast.c
+	rm -f $(TESTBINS) *.o blast.c get_capability.c smtpcode.c \
+	mailfrom_parms.c
 
 it: $(TESTBINS)
 
@@ -39,11 +41,11 @@ blast.o: ../compile blast.c
 
 unittest_blast: \
 ../load unittest_blast.o blast.o ../control.o ../ip.o ../constmap.o \
-../timeoutread.o ../timeoutwrite.o ../quote.o \
+../timeoutread.o ../timeoutwrite.o ../quote.o ../utf8read.o \
 ../stralloc.a ../str.a ../error.a ../substdio.a ../fs.a ../open.a ../str.a \
 ../getln.a ../case.a
 	../load unittest_blast blast.o ../control.o ../ip.o ../constmap.o \
-	../timeoutread.o ../timeoutwrite.o ../quote.o \
+	../timeoutread.o ../timeoutwrite.o ../quote.o ../utf8read.o \
 	../stralloc.a ../str.a ../error.a ../substdio.a ../fs.a ../open.a \
 	../getln.a ../str.a ../case.a \
 	`pkg-config --libs check`
@@ -62,3 +64,67 @@ unittest_prioq.o: \
 ../compile unittest_prioq.c
 	../compile unittest_prioq.c -I.. \
 	`pkg-config --cflags check`
+
+unittest_utf8read: \
+../load unittest_utf8read.o ../utf8read.o ../stralloc.a ../open.a \
+get_capability.o smtpcode.o ../scan_ulong.o ../str.a \
+mailfrom_parms.o ../substdio.a ../case.a
+	../load unittest_utf8read ../utf8read.o get_capability.o \
+	mailfrom_parms.o smtpcode.o ../scan_ulong.o ../stralloc.a \
+	../open.a ../substdio.a ../case.a ../str.a \
+	`pkg-config --libs check`
+
+unittest_utf8read.o: \
+../compile unittest_utf8read.c ../open.h ../str.h \
+../seek.h ../utf8read.h ../substdio.h ../subfd.h
+	../compile -I.. unittest_utf8read.c -I.. \
+	`pkg-config --cflags check`
+
+get_capability.o: \
+../compile get_capability.c
+	../compile -I.. get_capability.c
+
+get_capability.c: \
+../qmail-remote.c ./get_function
+	(echo "#include \"str.h\""; \
+	echo "#include \"case.h\""; \
+	echo "#include \"stralloc.h\""; \
+	echo "extern stralloc smtptext;"; \
+	./get_function "int get_capability" \
+		../qmail-remote.c) \
+		> get_capability.c
+
+smtpcode.o: \
+../compile smtpcode.c
+	../compile -I.. smtpcode.c
+
+smtpcode.c: \
+../qmail-remote.c ./get_function
+	(\
+	echo "#include \"stralloc.h\""; \
+	echo "#include \"substdio.h\""; \
+	echo "#include \"scan.h\""; \
+	echo "#define HUGESMTPTEXT 5000"; \
+	echo "extern stralloc smtptext;"; \
+	echo "extern substdio smtpfrom;"; \
+	echo "extern void temp_nomem();"; \
+	./get_function "static void get1" ../qmail-remote.c; \
+	./get_function "static unsigned long get3" ../qmail-remote.c; \
+	./get_function "unsigned long smtpcode" ../qmail-remote.c) > smtpcode.c
+
+mailfrom_parms.o: \
+../compile mailfrom_parms.c
+	../compile -I.. mailfrom_parms.c
+
+mailfrom_parms.c: \
+../qmail-smtpd.c ./get_function
+	(\
+	echo "#include \"stralloc.h\""; \
+	echo "#include \"str.h\""; \
+	echo "#include \"byte.h\""; \
+	echo "#include \"case.h\""; \
+	echo "extern stralloc mfparms;"; \
+	echo "extern int smtputf8;"; \
+	echo "extern void temp_nomem();"; \
+	./get_function "void mailfrom_parms" \
+	../qmail-smtpd.c|sed s}die_nomem}temp_nomem}g) > mailfrom_parms.c

--- a/tests/get_function
+++ b/tests/get_function
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Usage: get_function funcation_name filename
+# This script helps getting entire code snippet of a function
+# from the source code
+#
+start_line=`grep -n "^$1" $2|cut -d: -f1`
+sed -n "$start_line,$"p $2 | while IFS= read -r "line"
+do
+	echo "$line"
+	if [ " $line" = " }" ] ; then
+		break
+	fi
+done

--- a/tests/unittest_utf8read.c
+++ b/tests/unittest_utf8read.c
@@ -1,0 +1,376 @@
+#include <check.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "substdio.h"
+#include "alloc.h"
+#include "subfd.h"
+#include "open.h"
+#include "str.h"
+#include "seek.h"
+#include "utf8read.h"
+
+int flagutf8, smtputf8;
+stralloc smtptext = { 0 };
+stralloc mfparms = {0};
+char smtpfrombuf[128];
+
+void out(s) char *s; { if (substdio_puts(subfdoutsmall,s) == -1) _exit(0); }
+void temp_nomem() { out("Out of memory. (#4.3.0)\n"); }
+void temp_read() { out("Unable to read message. (#4.3.0)\n"); }
+void dropped() {out("ZConnected to xxxx but connection died (#4.4.2)\n");_exit(0);}
+
+substdio smtpfrom = SUBSTDIO_FDBUF(read,0,smtpfrombuf,sizeof(smtpfrombuf));
+extern int get_capability(const char *);
+extern unsigned long smtpcode();
+void mailfrom_parms(const char *);
+
+char maildata_1[] =
+  "Return-Path: <anonymous@argos.indimail.org>\n"
+  "Delivered-To: mbhangui@argos.indimail.org\n"
+  "Received: (indimail-mta 1842 invoked by alias); Thu, 3 Dec 2020 11:26:51 +0530\n"
+  "Delivered-To: root@argos.indimail.org\n"
+  "Received: (indimail-mta 3748 invoked by uid 0); Thu, 3 Dec 2020 10:30:00 +0530\n";
+
+char maildata_2[] =
+  "DKIM-Signature: v=1; a=rsa-sha1; c=relaxed/relaxed;\n"
+  "  d=argos.indimail.org; s=default; x=1607576400; h=Date:Message-ID:\n"
+  "  From:Subject:To; bh=pTv4MFW2fHcqP6Nreg/Zf8GFhtQ=; b=AD6ytMimMiPu\n"
+  "  kdbP9+hbH8rQqIiUP5uU+125jwlESXVXG8xdMzVPspmP4K4Lo4KkcUR86xKpC0ee\n"
+  "  Ak+T6fp3gqhZszbocYfag1YGIDTrc8fxmjf9Ycmg5BvGzxa+cEVs7CYfJ9hFZM7m\n"
+  "  0AvoOdQ5fmWMCThNoHJzWDC3rTH7JFI=\n"
+  "Date: Thu, 3 Dec 2020 10:29:33 +0530\n"
+  "Message-ID: <20201203045933.3741.indimail@argos>\n"
+  "From: anonymous@argos.indimail.org\n"
+  "Subject: Output from your job      110\n"
+  "To: root\n"
+  "\n"
+  "error: can't create transaction lock on /var/lib/rpm/.rpm.lock (Resource temporarily unavailable)\n"
+  "error: /tmp/skype.gpgsig.zgIdKM: key 1 import failed.\n";
+
+char *received[] = {
+  /*- one long received string */
+  "Received: from relay1.uu.net (HELO uunet.uu.net) (7@192.48.96.5) "
+  "by silverton.berkeley.edu with UTF8SMTP; 29 Nov 2020 04:46:54 -0000\n",
+  /*- with folded received header */
+  "Received: from relay1.uu.net (HELO uunet.uu.net) (7@192.48.96.5)\n" 
+  " by silverton.berkeley.edu with UTF8SMTP; 29 Nov 2020 04:46:54 -0000\n",
+  /*- with folded received header and extra space */
+  "Received: from relay1.uu.net (HELO uunet.uu.net) (7@192.48.96.5)\n"
+  "    by silverton.berkeley.edu with UTF8SMTP; 29 Nov 2020 04:46:54 -0000\n",
+  /*- with folded recvd header and extra space before UTF8SMTP keyword */
+  "Received: from relay1.uu.net (HELO uunet.uu.net) (7@192.48.96.5)\n"
+  "    by silverton.berkeley.edu with   UTF8SMTP; 29 Nov 2020 04:46:54 -0000\n",
+  0
+};
+
+char *ehlo_replies[] = {
+  /*- SMTP Greeting */
+  "220 indimail.org (NO UCE) ESMTP IndiMail 1.232 Sun, 6 Dec 2020 11:32:16 +0530\r\n",
+  /*- EHLO Response */
+  "250-indimail.org [::ffff:127.0.0.1]\r\n"
+  "250-AUTH LOGIN PLAIN CRAM-MD5 CRAM-SHA1 CRAM-SHA256 CRAM-SHA512 CRAM-RIPEMD DIGEST-MD5\r\n"
+  "250-PIPELINING\r\n"
+  "250-8BITMIME\r\n"
+  "250-SIZE 10000000\r\n"
+  "250-ETRN\r\n"
+  "250-STARTTLS\r\n"
+  "250-SMTPUTF8\r\n"
+  "250 HELP\r\n",
+  /*- Deliberate Wrong Data */
+  "gibberrish code\r\n",
+  /*- EHLO response with differing codes */
+  "250-indimail.org [::ffff:127.0.0.1]\r\n"
+  "250-PIPELINING\r\n"
+  "280-8BITMIME\r\n"
+  "250-SMTPUTF8\r\n"
+  "250 HELP\r\n",
+  /*- temporary error */
+  "420 Server unavailable\r\n",
+  0
+};
+
+char *mailfrom_str[] = {
+  "FROM:<abcd@notqmail.org> SIZE=2233 SMTPUTF8",
+  "FROM:<abcd@notqmail.org> SMTPUTF8",
+  "FROM:<abcd@notqmail.org> AUTH=abcd@notqmail.org SIZE=3434 SMTPUTF8",
+  "FROM:<abcd@notqmail.org> AUTH=abcd@notqmail.org SMTPUTF8 SIZE=23323",
+  "FROM:<abcd@notqmail.org> SMTPUTF8 AUTH=abcd@notqmail.org SIZE=23323",
+  "FROM:<abcd@notqmail.org> AUTH=abcd@notqmail.org SIZE=23323",
+};
+
+START_TEST(test_utf8read1)
+{
+  int fd, i, ret;
+
+  /*- non-utf mail */
+  fd = open("mail.txt", O_RDWR|O_TRUNC|O_CREAT,0644);
+  ck_assert_int_ne(fd, -1);
+  ret = write(fd, maildata_1, (i = str_len(maildata_1)));
+  ck_assert_int_eq(ret, i);
+  ret = write(fd, maildata_2, (i = str_len(maildata_2)));
+  ck_assert_int_eq(ret, i);
+  ret = seek_set(fd, 0);
+  ck_assert_int_eq(ret, 0);
+  ret = dup2(fd, 0);
+  ck_assert_int_ne(ret, -1);
+  ret = utf8read(); /*- we should return 0 */
+  ck_assert_int_eq(ret, 0);
+  close(fd);
+  unlink("mail.txt");
+}
+END_TEST
+
+START_TEST(test_utf8read2)
+{
+  int fd, i, j, ret;
+
+  for (j=0;j < 3;j++) {
+    /*- -utf mail2 */
+    flagutf8 = 0;
+    fd = open("mail.txt", O_RDWR|O_TRUNC|O_CREAT,0644);
+    ck_assert_int_ne(fd, -1);
+    ret = write(fd, maildata_1, (i = str_len(maildata_1)));
+    ck_assert_int_eq(ret, i);
+    ret = write(fd, received[j], (i = str_len(received[j])));
+    ck_assert_int_eq(ret, i);
+    ret = seek_set(fd, 0);
+    ck_assert_int_eq(ret, 0);
+    dup2(fd, 0);
+    ret = utf8read(); /*- we should return 1 */
+    ck_assert_int_eq(ret, 1);
+    close(fd);
+  }
+  unlink("mail.txt");
+}
+END_TEST
+
+START_TEST(test_utf8read3)
+{
+  int fd, i, ret;
+
+  /*- non-utf mail */
+  fd = open("mail.txt", O_RDWR|O_TRUNC|O_CREAT,0644);
+  ck_assert_int_ne(fd, -1);
+  ret = write(fd, maildata_1, (i = str_len(maildata_1)));
+  ck_assert_int_eq(ret, i);
+  ret = write(fd, maildata_2, (i = str_len(maildata_2)));
+  ck_assert_int_eq(ret, i);
+  ret = seek_set(fd, 0);
+  ck_assert_int_eq(ret, 0);
+  dup2(fd, 0);
+  flagutf8=1;
+  ret = utf8read(); /*- we should return 1 because flagutf8 is already set */
+  /*- we should return 1 because we have set the flagutf8 */
+  ck_assert_int_eq(ret, 1);
+  close(fd);
+  unlink("mail.txt");
+}
+END_TEST
+
+Suite *utf8read_suite(void)
+{
+    Suite *s;
+    TCase *tc_core;
+
+    s = suite_create("qmail-remote utf8read");
+
+    /* core test case */
+    tc_core = tcase_create("core");
+    tcase_add_test(tc_core, test_utf8read1);
+    tcase_add_test(tc_core, test_utf8read2);
+    tcase_add_test(tc_core, test_utf8read3);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+START_TEST(test_get_capability)
+{
+  int ret;
+
+  if (!stralloc_copys(&smtptext, ehlo_replies[1])
+      || !stralloc_0(&smtptext))
+    temp_nomem();
+  ret = get_capability("SMTPUTF8");
+  ck_assert_int_eq(ret, 1);
+  ret = get_capability("STARTTLS");
+  ck_assert_int_eq(ret, 1);
+  ret = get_capability("ENHANCEDSTATUSCODES");
+  ck_assert_int_eq(ret, 0);
+  ret = get_capability("DSN");
+  ck_assert_int_eq(ret, 0);
+}
+END_TEST
+
+Suite *capability_suite(void)
+{
+    Suite *s;
+    TCase *tc_capa;
+    s = suite_create("qmail-remote capability");
+    tc_capa = tcase_create("capa");
+    tcase_add_test(tc_capa, test_get_capability);
+    suite_add_tcase(s, tc_capa);
+  return s;
+}
+
+/*- here we test 4 cases
+ * 1: SMTP server greeting 220
+ * 2: Test with some gibberish data.
+ * 3: Test with a multiline output
+ * 4: Test with a multiline output with differing codes in each line
+ */
+START_TEST(test_smtpcode1)
+{
+  int fd, i, ret;
+  unsigned long code;
+
+  /*- smtpcode test 1 */
+  fd = open("smtpcodes.tmp", O_RDWR|O_TRUNC|O_CREAT,0644);
+  ck_assert_int_ne(fd, -1);
+  /*- write greeting */
+  ret = write(fd, ehlo_replies[0], (i = str_len(ehlo_replies[0])));
+  ck_assert_int_eq(ret, i);
+  ret = seek_set(fd, 0);
+  ck_assert_int_eq(ret, 0);
+  dup2(fd, 0);
+  code = smtpcode();
+  ck_assert_int_eq(code, 220);
+  close(fd);
+  unlink("smtpcodes.tmp");
+}
+END_TEST
+
+START_TEST(test_smtpcode2)
+{
+  int fd, i, ret;
+  unsigned long code;
+  /*- smtpcode test 2 */
+  fd = open("smtpcodes.tmp", O_RDWR|O_TRUNC|O_CREAT,0644);
+  ck_assert_int_ne(fd, -1);
+  /*- test multiline EHLO response*/
+  ret = write(fd, ehlo_replies[1], (i = str_len(ehlo_replies[1])));
+  ck_assert_int_eq(ret, i);
+  ret = seek_set(fd, 0);
+  ck_assert_int_eq(ret, 0);
+  dup2(fd, 0);
+  code = smtpcode();
+  ck_assert_int_eq(code, 250);
+  close(fd);
+  unlink("smtpcodes.tmp");
+}
+END_TEST
+
+START_TEST(test_smtpcode3)
+{
+  int fd, i, ret;
+  unsigned long code;
+  /*- smtpcode test 3 */
+  fd = open("smtpcodes.tmp", O_RDWR|O_TRUNC|O_CREAT,0644);
+  ck_assert_int_ne(fd, -1);
+  /*- write gibberish data so that smtpcode returns failure */
+  ret = write(fd, ehlo_replies[2], (i = str_len(ehlo_replies[2])));
+  ck_assert_int_eq(ret, i);
+  ret = seek_set(fd, 0);
+  ck_assert_int_eq(ret, 0);
+  dup2(fd, 0);
+  code = smtpcode();
+  ck_assert_int_eq(code, 400);
+  close(fd);
+  unlink("smtpcodes.tmp");
+}
+END_TEST
+
+START_TEST(test_smtpcode4)
+{
+  int fd, i, ret;
+  unsigned long code;
+  /*- smtpcode test 4 */
+  fd = open("smtpcodes.tmp", O_RDWR|O_TRUNC|O_CREAT,0644);
+  ck_assert_int_ne(fd, -1);
+  /*- test multiline EHLO response*/
+  ret = write(fd, ehlo_replies[3], (i = str_len(ehlo_replies[3])));
+  ck_assert_int_eq(ret, i);
+  ret = seek_set(fd, 0);
+  ck_assert_int_eq(ret, 0);
+  dup2(fd, 0);
+  code = smtpcode();
+  ck_assert_int_ne(code, 250);
+  close(fd);
+  unlink("smtpcodes.tmp");
+}
+END_TEST
+
+Suite *smtpcode_suite(void)
+{
+  Suite *s;
+  TCase *tc_smtpcode;
+  s = suite_create("qmail-remote smtpcode");
+  tc_smtpcode = tcase_create("smtpcode");
+  tcase_add_test(tc_smtpcode, test_smtpcode1);
+  tcase_add_test(tc_smtpcode, test_smtpcode2);
+  tcase_add_test(tc_smtpcode, test_smtpcode3);
+  tcase_add_test(tc_smtpcode, test_smtpcode4);
+  suite_add_tcase(s, tc_smtpcode);
+  return s;
+}
+
+START_TEST(test_mailfrom_parms)
+{
+  int fd, i, ret;
+
+  for (i=0;i<5;i++) {
+    smtputf8=0;
+    mailfrom_parms(mailfrom_str[i]);
+    ck_assert_int_eq(smtputf8, 1);
+  }
+  smtputf8=0;
+  mailfrom_parms(mailfrom_str[5]);
+  ck_assert_int_ne(smtputf8, 1);
+}
+END_TEST
+
+Suite *mailfrom_parms_suite(void)
+{
+  Suite *s;
+  TCase *tc_mailfrom_parms;
+  s = suite_create("qmail-smtpd mailfrom_parms");
+  tc_mailfrom_parms = tcase_create("mailfrom_parms");
+  tcase_add_test(tc_mailfrom_parms, test_mailfrom_parms);
+  suite_add_tcase(s, tc_mailfrom_parms);
+  return s;
+}
+
+int main(void)
+{
+  int number_failed;
+  Suite *s1, *s2, *s3, *s4;
+  SRunner *sr1, *sr2, *sr3, *sr4;
+
+  s1 = utf8read_suite();
+  s2 = capability_suite();
+  s3 = smtpcode_suite();
+  s4 = mailfrom_parms_suite();
+  sr1 = srunner_create(s1);
+  sr2 = srunner_create(s2);
+  sr3 = srunner_create(s3);
+  sr4 = srunner_create(s4);
+
+  srunner_run_all(sr1, CK_NORMAL);
+  number_failed = srunner_ntests_failed(sr1);
+
+  srunner_run_all(sr2, CK_NORMAL);
+  number_failed += srunner_ntests_failed(sr2);
+
+  srunner_run_all(sr3, CK_NORMAL);
+  number_failed += srunner_ntests_failed(sr3);
+
+  srunner_run_all(sr4, CK_NORMAL);
+  number_failed += srunner_ntests_failed(sr4);
+
+  srunner_free(sr1);
+  srunner_free(sr2);
+  srunner_free(sr3);
+  srunner_free(sr4);
+  return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tryidn2.c
+++ b/tryidn2.c
@@ -1,0 +1,13 @@
+#ifdef SMTPUTF8
+#include <idn2.h>
+#endif
+int
+main(int argc, char **argv)
+{
+#ifdef SMTPUTF8
+	char           *ascii;
+	idn2_lookup_u8((const uint8_t *) argv[1], (uint8_t **) &ascii, IDN2_NFC_INPUT);
+#else
+	:
+#endif
+}

--- a/utf8read.c
+++ b/utf8read.c
@@ -1,0 +1,77 @@
+#include "hassmtputf8.h"
+
+#ifdef SMTPUTF8
+#include "utf8read.h"
+#include "stralloc.h"
+#include "case.h"
+#include "substdio.h"
+#include "subfd.h"
+
+static stralloc receivedline = { 0 };
+stralloc        header = { 0 };
+extern void temp_nomem();
+extern void temp_read();
+
+int
+containsutf8(unsigned char *p, int l)
+{
+	int             i = 0;
+
+	while (i < l)
+		if (p[i++] > 127)
+			return 1;
+	return 0;
+}
+
+int
+utf8read()
+{
+  int             r, i, received = 0;
+  char            ch;
+
+  if (flagutf8)
+    return 1;
+  /*- initialize headers so that we don't create if called more than once */
+  header.len = receivedline.len = 0;
+  for (;;) {
+    r = substdio_get(subfdin, &ch, 1);
+    if (r == 0) break;
+    if (r == -1) temp_read();
+
+    if (ch == '\n') {
+      if (!stralloc_append(&header, "\r")) temp_nomem(); /* received.c does not add '\r' */
+      if (!stralloc_append(&header, "\n")) temp_nomem();
+      if (case_starts(receivedline.s, "Date:")) return 0;  /* header to quit asap */
+      if (case_starts(receivedline.s, "Received: from")) received++;  /* found Received header */
+      if (received) {
+        for (i = 0; i < receivedline.len; i++)
+          if (*(receivedline.s + i) != ' ' && *(receivedline.s + i) != '\t')
+            break;
+        if (case_starts(receivedline.s + i, "by ")) {
+          for (i += 3; i < receivedline.len; ++i)
+            if (*(receivedline.s + i) == ' ' || *(receivedline.s + i) == '\t')
+              if (case_starts(receivedline.s + i + 1, "with UTF8")) {
+                flagutf8 = 1;return 1;
+              }
+          return 0;
+        }
+        for (i = 0; i < receivedline.len; i++) {
+          if (case_starts(receivedline.s + i, "by ")) {
+            for (i += 3; i < receivedline.len; ++i)
+              if (*(receivedline.s + i) == ' ' || *(receivedline.s + i) == '\t')
+                if (case_starts(receivedline.s + i + 1, "with UTF8")) {
+                  flagutf8 = 1;return 1;
+                }
+            return 0;
+          }
+        }
+      }
+      if (!stralloc_copys(&receivedline, "")) temp_nomem();
+    } else {
+      if (!stralloc_append(&header, &ch)) temp_nomem();
+      if (!stralloc_catb(&receivedline, &ch, 1)) temp_nomem();
+    }
+  }
+  return 0;
+}
+#endif

--- a/utf8read.h
+++ b/utf8read.h
@@ -1,0 +1,10 @@
+#ifndef UTF8READ_H
+#define UTF8READ_H
+#include "stralloc.h"
+
+extern int utf8read();
+extern int containsutf8(unsigned char *, int);
+extern stralloc header;
+extern int flagutf8;
+
+#endif


### PR DESCRIPTION
This adds EAI support to notqmail. Adapted from dapted from Arnt Gulbrandsen unicode address
support [here](http://arnt.gulbrandsen.priv.no/qmail/qmail-smtputf8.patch).

1. Use conf-smtputf8 to compile the EAI support
2. If conf-smtputf8 has -DSMTPUTF8, use tryidn2 to see if idn2_lookup_u8() from libidn2 can be used.
   if Yes, create hassmtputf8.h and #define SMTPUTF8
3. include hassmtputf8.h in qmail-smtpd.c, qmail-remote.c
4. The utf8read() function has been adapted from utf8received() by
   Erwin Hoffman
5. Following unit tests cases have been added
   - smtpcode() - in qmail-remote.c (test 3 digit codes, valid
     and junk codes)
   - mailfrom_parms() in qmail-smtpd.c (test SMTPUTF8 in the
     MAIL FROM parameter)
   - utf8read() in qmail-remote.c (test utf8, non-utf8)
   - get_capability() in qmail-remote.c to test for presence of EHLO
     capability