### PR TITLE
Fix 3 warnings from -Wpointer-sign.

### DIFF
--- a/auto-str.c
+++ b/auto-str.c
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
 
   while ((ch = *value++)) {
     if (is_legible(ch)) {
-      if (substdio_put(&ss1, &ch, 1) == -1)
+      if (substdio_put(&ss1, (char *)&ch, 1) == -1)
         _exit(111);
     } else {
       puts("\\");

--- a/cdbmss.c
+++ b/cdbmss.c
@@ -28,8 +28,8 @@ unsigned int datalen;
   cdbmake_pack(c->packbuf,(uint32) keylen);
   cdbmake_pack(c->packbuf + 4,(uint32) datalen);
   if (substdio_put(&c->ss,c->packbuf,8) == -1) return -1;
-  if (substdio_put(&c->ss,key,keylen) == -1) return -1;
-  if (substdio_put(&c->ss,data,datalen) == -1) return -1;
+  if (substdio_put(&c->ss,(char *)key,keylen) == -1) return -1;
+  if (substdio_put(&c->ss,(char *)data,datalen) == -1) return -1;
 
   h = CDBMAKE_HASHSTART;
   for (i = 0;i < keylen;++i)


### PR DESCRIPTION
The clang warning message says "converts between pointers to integer
types with different sign". Cast the unsigned char * argument to char *
to match the expected parameter.