### PR TITLE
tcpto.c: initialize firstwhen variable

### DIFF
--- a/tcpto.c
+++ b/tcpto.c
@@ -74,6 +74,7 @@ void tcpto_err(ip,flagerr) struct ip_address *ip; int flagerr;
  char *record;
  datetime_sec when;
  datetime_sec lastwhen;
+ datetime_sec firstwhen = 0;
 
  if (!flagerr)
    if (!flagwasthere)
@@ -126,7 +127,6 @@ void tcpto_err(ip,flagerr) struct ip_address *ip; int flagerr;
  if (i >= n)
   {
    int firstpos = -1;
-   datetime_sec firstwhen;
    record = tcpto_buf;
    for (i = 0;i < n;++i)
     {


### PR DESCRIPTION
Initialize firstwhen variable in tcpto.c and fix compiler warning