### PR TITLE
do not use Posix style -n argument for tail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ compile auto_usera.c
 
 auto_userd.c: \
 auto-str conf-users
-	./auto-str auto_userd `head -n 2 conf-users | tail -n -1` > auto_userd.c
+	./auto-str auto_userd `head -n 2 conf-users | tail -1` > auto_userd.c
 
 auto_userd.o: \
 compile auto_userd.c
@@ -123,7 +123,7 @@ compile auto_userd.c
 
 auto_userl.c: \
 auto-str conf-users
-	./auto-str auto_userl `head -n 3 conf-users | tail -n -1` > auto_userl.c
+	./auto-str auto_userl `head -n 3 conf-users | tail -1` > auto_userl.c
 
 auto_userl.o: \
 compile auto_userl.c
@@ -131,7 +131,7 @@ compile auto_userl.c
 
 auto_usero.c: \
 auto-str conf-users
-	./auto-str auto_usero `head -n 4 conf-users | tail -n -1` > auto_usero.c
+	./auto-str auto_usero `head -n 4 conf-users | tail -1` > auto_usero.c
 
 auto_usero.o: \
 compile auto_usero.c
@@ -139,7 +139,7 @@ compile auto_usero.c
 
 auto_userp.c: \
 auto-str conf-users
-	./auto-str auto_userp `head -n 5 conf-users | tail -n -1` > auto_userp.c
+	./auto-str auto_userp `head -n 5 conf-users | tail -1` > auto_userp.c
 
 auto_userp.o: \
 compile auto_userp.c
@@ -147,7 +147,7 @@ compile auto_userp.c
 
 auto_userq.c: \
 auto-str conf-users
-	./auto-str auto_userq `head -n 6 conf-users | tail -n -1` > auto_userq.c
+	./auto-str auto_userq `head -n 6 conf-users | tail -1` > auto_userq.c
 
 auto_userq.o: \
 compile auto_userq.c
@@ -155,7 +155,7 @@ compile auto_userq.c
 
 auto_userr.c: \
 auto-str conf-users
-	./auto-str auto_userr `head -n 7 conf-users | tail -n -1` > auto_userr.c
+	./auto-str auto_userr `head -n 7 conf-users | tail -1` > auto_userr.c
 
 auto_userr.o: \
 compile auto_userr.c
@@ -163,7 +163,7 @@ compile auto_userr.c
 
 auto_users.c: \
 auto-str conf-users
-	./auto-str auto_users `head -n 8 conf-users | tail -n -1` > auto_users.c
+	./auto-str auto_users `head -n 8 conf-users | tail -1` > auto_users.c
 
 auto_users.o: \
 compile auto_users.c
@@ -171,7 +171,7 @@ compile auto_users.c
 
 auto_groupn.c: \
 auto-str conf-groups
-	./auto-str auto_groupn `head -n 2 conf-groups | tail -n -1` > auto_groupn.c
+	./auto-str auto_groupn `head -n 2 conf-groups | tail -1` > auto_groupn.c
 
 auto_groupn.o: \
 compile auto_groupn.c


### PR DESCRIPTION
This was accidentially was changed from "tail -1" to "tail -n -1" instead of "tail -n 1". Even worse, the tail on Solaris doesn't seem to work with either options.