### PR TITLE
fix "make clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ auto_spawn.h
 
 clean: \
 TARGETS
-	rm -f `cat TARGETS`
+	rm -f `grep -v '^#' TARGETS`
 	$(MAKE) -C tests clean
 
 coe.o: \


### PR DESCRIPTION
The comment would be taken word by word as filenames, resulting in .gitignore
and TARGETS being deleted on "make clean".

Fixes 8ea74d67af38ca843c28a1d9b18f6a643c931a6d