### PR TITLE
[WIP] Add a patch breakage checker to cirrus build

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -1,0 +1,17 @@
+name: "Patch Compatibility"
+
+on:
+  push:
+    branches: [master, ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+jobs:
+  analyse:
+    name: Analyse
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout notqmail-patch
+      run: git clone https://github.com/josuah/notqmail-patch/
+    - name: Test whether we broke more patches than master did
+      run: make -C notqmail-patch BRANCH=${{ github.sha }} brokemaster


### PR DESCRIPTION
I propose to move my https://github.com/josuah/notqmail-patch to https://github.com/notqmail/notqmail-patch (or any better name), so that anyone allowed to alter notqmail can also alter notqmail-patch.

Then, what about this to check for patch compatiblity ?

This also lets us maintain adapted versions of the patches, and adapt them as we break them.

In the end, some way for us to keep patches going as we move things around.