### PR TITLE
qmail-inject: fix header parse regression

### DIFF
--- a/qmail-inject.c
+++ b/qmail-inject.c
@@ -76,6 +76,14 @@ void doordie(sa,r) stralloc *sa; int r; {
  if (r == 1) return; if (r == -1) die_nomem();
  substdio_putsflush(subfderr,"qmail-inject: fatal: unable to parse this line:\n");
  substdio_putflush(subfderr,sa->s,sa->len); perm(); }
+/* call doordie, but if q is set ignore parse errors (i.e. r == 0) */
+static int doordie_rh(stralloc *sa, int r, int q)
+{
+  if (q && r == 0)
+    return 0;
+  doordie(sa, r);
+  return 1;
+}
 
 GEN_ALLOC_typedef(saa,stralloc,sa,len,a)
 GEN_ALLOC_readyplus(saa,stralloc,sa,len,a,10,saa_readyplus)
@@ -347,6 +355,7 @@ stralloc *h;
 {
   int htype;
   int (*rw)() = 0;
+  int rwmayfail = 0;
  
   htype = hfield_known(h->s,h->len);
   if (flagdeletefrom) if (htype == H_FROM) return;
@@ -361,13 +370,16 @@ stralloc *h;
  
   switch(htype) {
     case H_TO: case H_CC:
-      if (flagrh) rw = rwtocc;
+      rw = rwtocc;
+      rwmayfail = 1;
       break;
     case H_BCC: case H_APPARENTLYTO:
-      if (flagrh) rw = rwhr;
+      rw = rwhr;
+      rwmayfail = 1;
       break;
     case H_R_TO: case H_R_CC: case H_R_BCC:
-      if (flagrh) rw = rwhrr;
+      rw = rwhrr;
+      rwmayfail = 1;
       break;
     case H_RETURNPATH:
       rw = rwreturn; break;
@@ -378,10 +390,11 @@ stralloc *h;
   }
 
   if (rw) {
-    doordie(h,token822_parse(&hfin,h,&hfbuf));
-    doordie(h,token822_addrlist(&hfrewrite,&hfaddr,&hfin,rw));
-    if (token822_unparse(h,&hfrewrite,LINELEN) != 1)
-      die_nomem();
+    if (doordie_rh(h,token822_parse(&hfin,h,&hfbuf),rwmayfail) &&
+        doordie_rh(h,token822_addrlist(&hfrewrite,&hfaddr,&hfin,rw),rwmayfail)) {
+      if (token822_unparse(h,&hfrewrite,LINELEN) != 1)
+        die_nomem();
+    }
   }
  
   if (htype == H_BCC) return;


### PR DESCRIPTION
When attempting to catch incorrectly formatted headers like "To: foo: bar, baz" to avoid errors when injecting bounces the host expansion of headers like "To: root" was also broken.

Instead of completely ignoring these lines when the recipient list was already given on the command line using -a option try to process these lines as before, but allow the parsing of these lines to silently fail. If a broken line is encountered this now simply does not reformat them to insert the hostname.

Bug introduced in commit 56e7c4a74087d47889355c2c55352cc4d0482020 in 1.08.

Fixes: #147

As I already said in that bug: I think we should just merge this without the tests so we can get a 1.09 out of the door. This fixes the regression, and when comparing the code before the breaking commit and this branch you see that it now only adds the "ignore errors" flag and routes the ```doordie()``` calls through a little helper that checks that flag. @schmonz verified that his usecase with the installed version now works.