### PR TITLE
autobuild updates

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -70,7 +70,14 @@ jobs:
       uses: actions/checkout@v2
 
     - name: test_deps
-      run: if [ "${OS}" = "macos-latest" ]; then brew install check; else sudo apt-get install check; fi
+      run: |
+        if [ "${OS}" = "macos-latest" ]; then
+          brew install check
+        else
+          sudo sh -c 'echo "deb http://azure.archive.ubuntu.com/ubuntu hirsute universe" >> /etc/apt/sources.list'
+          sudo apt-get update
+          sudo apt-get install check
+        fi
       env:
         OS: ${{ matrix.host }}
 

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -10,21 +10,22 @@ on:
 jobs:
   build:
     name: Solaris-${{ matrix.config.name }}
-    runs-on: macos-latest
+    runs-on: macos-10.15
     env:
       CFLAGS: ${{ matrix.config.cflags }}
       NROFF: ${{ matrix.config.nroff }}
+      LIBCHECK_VERSION: "0.15.2"
     strategy:
       fail-fast: false
       matrix:
         config:
          - {
-           name: default,
+           name: default64,
            nroff: nroff,
            cflags: ""
          }
          - {
-           name: no_obsolete,
+           name: no_obsolete64,
            nroff: true,
            cflags: "-DDEPRECATED_FUNCTIONS_REMOVED"
          }
@@ -35,13 +36,21 @@ jobs:
 
     - name: Test in solaris
       id: test
-      uses: vmactions/solaris-vm@v0.0.2
+      uses: vmactions/solaris-vm@v0.0.5
       with:
-        envs: 'CFLAGS NROFF'
-        prepare: pkgutil -y -i libcheck_dev gcc4core pkgconfig
+        envs: 'CFLAGS NROFF LIBCHECK_VERSION'
+        prepare: |
+          pkgutil -y -i gcc4core pkgconfig curl
+          curl -L -O https://github.com/libcheck/check/releases/download/${LIBCHECK_VERSION}/check-${LIBCHECK_VERSION}.tar.gz
+          gunzip check-${LIBCHECK_VERSION}.tar.gz
+          tar -xvf check-${LIBCHECK_VERSION}.tar
+          cd check-${LIBCHECK_VERSION}
+          env CFLAGS="-m64" ./configure --prefix=/opt/csw && gmake && gmake install
+          sed -e 's|^Libs: |Libs: -Wl,-R${libdir} |' < /opt/csw/lib/pkgconfig/check.pc > /opt/csw/lib/pkgconfig/check.pc.tmp && mv /opt/csw/lib/pkgconfig/check.pc.tmp /opt/csw/lib/pkgconfig/check.pc
         run: |
-          echo "gcc -O2 -pipe ${CFLAGS}" > conf-cc
-          echo "gcc -s" > conf-ld
+          echo "gcc -m64 -O2 -pipe ${CFLAGS}" > conf-cc
+          sed -e 's|ar cr |ar Scr |g' make-makelib.sh > make-makelib.sh.tmp && mv make-makelib.sh.tmp make-makelib.sh
+          echo "gcc -m64 -s" > conf-ld
           make it man NROFF=${NROFF}
           cd tests
           make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Don't edit Makefile! Use conf-* for configuration.
 
 SHELL=/bin/sh
-NROFF?=nroff
+NROFF=nroff
 
 default: it
 

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ auto_spawn.h
 clean: \
 TARGETS
 	rm -f `grep -v '^#' TARGETS`
-	$(MAKE) -C tests clean
+	cd tests && $(MAKE) clean
 
 coe.o: \
 compile coe.c coe.h
@@ -1878,7 +1878,7 @@ compile tcpto_clean.c tcpto.h open.h substdio.h readwrite.h
 	./compile tcpto_clean.c
 
 test: it
-	@$(MAKE) -C tests test
+	@cd tests && $(MAKE) test
 
 timeoutconn.o: \
 compile timeoutconn.c ndelay.h select.h error.h readwrite.h ip.h \


### PR DESCRIPTION
Fix the broken Solaris builds, including (I believe) solutions to #203 and #209.

As a prerequisite to #224, we need a newer libcheck on Solaris and Ubuntu. For the latter, we can get away with installing a binary package from a newer Ubuntu; for the former, we build from source. It might be worth following up this PR with one that [caches the built libcheck](https://github.com/actions/cache), as the Solaris builds are already very slow.