### PR TITLE
basic SMTP recipient checking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 - 20220202 code: apply Jay Soffian's RCPTCHECK patch to qmail-smtpd(8),
-           and add qmail-rcptcheck-realrcptto(8) derived from Paul
-           Jarc's qmail-realrcptto patch
+           add qmail-rcptcheck(8) to run an admin-defined sequence of
+           checks, and add qmail-rcptcheck-realrcptto(8) derived from
+           Paul Jarc's qmail-realrcptto patch
 - 20210122 code: remove register storage class declaration from codebase.
 - 20201224 bug: in qmail-remote, handle DNS packets up to max EDNS
            response size.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+- 20220202 code: apply Jay Soffian's RCPTCHECK patch to qmail-smtpd(8),
+           and add qmail-rcptcheck-realrcptto(8) derived from Paul
+           Jarc's qmail-realrcptto patch
 - 20210122 code: remove register storage class declaration from codebase.
 - 20201224 bug: in qmail-remote, handle DNS packets up to max EDNS
            response size.

--- a/Makefile
+++ b/Makefile
@@ -778,6 +778,7 @@ qmail-pw2u qmail-qread qmail-qstat qmail-tcpto qmail-tcpok \
 qmail-pop3d qmail-popup qmail-qmqpc qmail-qmqpd qmail-qmtpd \
 qmail-smtpd sendmail tcp-env qmail-newmrh config config-fast \
 dnsptr dnsip dnsfq hostname ipmeprint qreceipt qbiff \
+qmail-rcptcheck-realrcptto \
 forward preline condredirect bouncesaying except maildirmake \
 maildir2mbox install instpackage instqueue instchown \
 instcheck home home+df proc proc+df binm1 binm1+df binm2 binm2+df \
@@ -882,6 +883,7 @@ qmail-queue.0 qmail-inject.0 mailsubj.0 qmail-showctl.0 qmail-newu.0 \
 qmail-pw2u.0 qmail-qread.0 qmail-qstat.0 qmail-tcpto.0 qmail-tcpok.0 \
 qmail-pop3d.0 qmail-popup.0 qmail-qmqpc.0 qmail-qmqpd.0 qmail-qmtpd.0 \
 qmail-smtpd.0 tcp-env.0 qmail-newmrh.0 qreceipt.0 qbiff.0 forward.0 \
+qmail-rcptcheck-realrcptto.0 \
 preline.0 condredirect.0 bouncesaying.0 except.0 maildirmake.0 \
 maildir2mbox.0 qmail.0 qmail-limits.0 qmail-log.0 \
 qmail-control.0 qmail-header.0 qmail-users.0 dot-qmail.0 \
@@ -1287,15 +1289,14 @@ sig.h substdio.h readwrite.h exit.h now.h datetime.h fmt.h env.h byte.h
 	./compile qmail-qmqpd.c
 
 qmail-qmtpd: \
-load qmail-qmtpd.o realrcptto.o rcpthosts.o control.o constmap.o received.o \
+load qmail-qmtpd.o rcpthosts.o control.o constmap.o received.o \
 date822fmt.o qmail.o cdb.a fd.a wait.a datetime.a open.a \
 getln.a sig.a case.a env.a stralloc.a substdio.a error.a \
-str.a fs.a auto_qmail.o auto_break.o auto_usera.o
-	./load qmail-qmtpd realrcptto.o rcpthosts.o control.o constmap.o \
+str.a fs.a auto_qmail.o
+	./load qmail-qmtpd rcpthosts.o control.o constmap.o \
 	received.o date822fmt.o qmail.o cdb.a fd.a wait.a \
 	datetime.a open.a getln.a sig.a case.a env.a stralloc.a \
-	substdio.a error.a str.a fs.a auto_qmail.o auto_break.o \
-	auto_usera.o
+	substdio.a error.a str.a fs.a auto_qmail.o
 
 qmail-qmtpd.0: \
 qmail-qmtpd.8
@@ -1353,6 +1354,26 @@ compile qmail-queue.c readwrite.h sig.h exit.h open.h seek.h fmt.h \
 alloc.h substdio.h datetime.h now.h datetime.h triggerpull.h extra.h \
 uidgid.h auto_qmail.h auto_uids.h auto_users.h date822fmt.h fmtqfn.h
 	./compile qmail-queue.c
+
+qmail-rcptcheck-realrcptto: \
+load qmail-rcptcheck-realrcptto.o realrcptto.o auto_break.o \
+auto_usera.o control.o constmap.o timeoutwrite.o \
+case.a cdb.a env.a error.a fs.a getln.a open.a str.a stralloc.a \
+substdio.a
+	./load qmail-rcptcheck-realrcptto realrcptto.o auto_break.o \
+	auto_usera.o control.o constmap.o timeoutwrite.o \
+	case.a cdb.a env.a error.a fs.a getln.a open.a str.a stralloc.a \
+	substdio.a
+
+qmail-rcptcheck-realrcptto.o: \
+compile qmail-rcptcheck-realrcptto.c env.h realrcptto.h
+	./compile qmail-rcptcheck-realrcptto.c
+
+qmail-rcptcheck-realrcptto.8: \
+qmail-rcptcheck-realrcptto.9 conf-qmail
+	cat qmail-rcptcheck-realrcptto.9 \
+	| sed s}QMAILHOME}"`head -n 1 conf-qmail`"}g \
+	> qmail-rcptcheck-realrcptto.8
 
 qmail-remote: \
 load qmail-remote.o control.o constmap.o timeoutread.o timeoutwrite.o \
@@ -1451,17 +1472,17 @@ auto_spawn.h auto_split.h
 	./compile qmail-showctl.c
 
 qmail-smtpd: \
-load qmail-smtpd.o realrcptto.o rcpthosts.o commands.o timeoutread.o \
+load qmail-smtpd.o rcpthosts.o commands.o timeoutread.o \
 timeoutwrite.o ip.o ipme.o ipalloc.o control.o constmap.o received.o \
 date822fmt.o qmail.o cdb.a fd.a wait.a datetime.a getln.a \
 open.a sig.a case.a env.a stralloc.a substdio.a error.a str.a \
-fs.a auto_qmail.o auto_break.o auto_usera.o socket.lib
-	./load qmail-smtpd realrcptto.o rcpthosts.o commands.o timeoutread.o \
+fs.a auto_qmail.o socket.lib
+	./load qmail-smtpd rcpthosts.o commands.o timeoutread.o \
 	timeoutwrite.o ip.o ipme.o ipalloc.o control.o constmap.o \
 	received.o date822fmt.o qmail.o cdb.a fd.a wait.a \
 	datetime.a getln.a open.a sig.a case.a env.a stralloc.a \
-	substdio.a error.a str.a fs.a auto_qmail.o auto_break.o \
-	auto_usera.o `cat socket.lib`
+	substdio.a error.a str.a fs.a auto_qmail.o  `cat \
+	socket.lib`
 
 qmail-smtpd.0: \
 qmail-smtpd.8

--- a/Makefile
+++ b/Makefile
@@ -1287,14 +1287,15 @@ sig.h substdio.h readwrite.h exit.h now.h datetime.h fmt.h env.h byte.h
 	./compile qmail-qmqpd.c
 
 qmail-qmtpd: \
-load qmail-qmtpd.o rcpthosts.o control.o constmap.o received.o \
+load qmail-qmtpd.o realrcptto.o rcpthosts.o control.o constmap.o received.o \
 date822fmt.o qmail.o cdb.a fd.a wait.a datetime.a open.a \
 getln.a sig.a case.a env.a stralloc.a substdio.a error.a \
-str.a fs.a auto_qmail.o
-	./load qmail-qmtpd rcpthosts.o control.o constmap.o \
+str.a fs.a auto_qmail.o auto_break.o auto_usera.o
+	./load qmail-qmtpd realrcptto.o rcpthosts.o control.o constmap.o \
 	received.o date822fmt.o qmail.o cdb.a fd.a wait.a \
 	datetime.a open.a getln.a sig.a case.a env.a stralloc.a \
-	substdio.a error.a str.a fs.a auto_qmail.o
+	substdio.a error.a str.a fs.a auto_qmail.o auto_break.o \
+	auto_usera.o
 
 qmail-qmtpd.0: \
 qmail-qmtpd.8
@@ -1450,17 +1451,17 @@ auto_spawn.h auto_split.h
 	./compile qmail-showctl.c
 
 qmail-smtpd: \
-load qmail-smtpd.o rcpthosts.o commands.o timeoutread.o \
+load qmail-smtpd.o realrcptto.o rcpthosts.o commands.o timeoutread.o \
 timeoutwrite.o ip.o ipme.o ipalloc.o control.o constmap.o received.o \
 date822fmt.o qmail.o cdb.a fd.a wait.a datetime.a getln.a \
 open.a sig.a case.a env.a stralloc.a substdio.a error.a str.a \
-fs.a auto_qmail.o socket.lib
-	./load qmail-smtpd rcpthosts.o commands.o timeoutread.o \
+fs.a auto_qmail.o auto_break.o auto_usera.o socket.lib
+	./load qmail-smtpd realrcptto.o rcpthosts.o commands.o timeoutread.o \
 	timeoutwrite.o ip.o ipme.o ipalloc.o control.o constmap.o \
 	received.o date822fmt.o qmail.o cdb.a fd.a wait.a \
 	datetime.a getln.a open.a sig.a case.a env.a stralloc.a \
-	substdio.a error.a str.a fs.a auto_qmail.o  `cat \
-	socket.lib`
+	substdio.a error.a str.a fs.a auto_qmail.o auto_break.o \
+	auto_usera.o `cat socket.lib`
 
 qmail-smtpd.0: \
 qmail-smtpd.8
@@ -1590,6 +1591,11 @@ readsubdir.o: \
 compile readsubdir.c readsubdir.h direntry.h fmt.h scan.h str.h \
 auto_split.h
 	./compile readsubdir.c
+
+realrcptto.o: \
+compile realrcptto.c auto_break.h auto_usera.h byte.h case.h cdb.h \
+constmap.h error.h fmt.h open.h str.h stralloc.h uint32.h
+	./compile realrcptto.c
 
 received.o: \
 compile received.c fmt.h qmail.h substdio.h now.h datetime.h \

--- a/Makefile
+++ b/Makefile
@@ -1593,7 +1593,7 @@ auto_split.h
 	./compile readsubdir.c
 
 realrcptto.o: \
-compile realrcptto.c auto_break.h auto_usera.h byte.h case.h cdb.h \
+compile realrcptto.c auto_break.h auto_users.h byte.h case.h cdb.h \
 constmap.h error.h fmt.h open.h str.h stralloc.h uint32.h
 	./compile realrcptto.c
 

--- a/Makefile
+++ b/Makefile
@@ -778,7 +778,7 @@ qmail-pw2u qmail-qread qmail-qstat qmail-tcpto qmail-tcpok \
 qmail-pop3d qmail-popup qmail-qmqpc qmail-qmqpd qmail-qmtpd \
 qmail-smtpd sendmail tcp-env qmail-newmrh config config-fast \
 dnsptr dnsip dnsfq hostname ipmeprint qreceipt qbiff \
-qmail-rcptcheck-realrcptto \
+qmail-rcptcheck qmail-rcptcheck-realrcptto \
 forward preline condredirect bouncesaying except maildirmake \
 maildir2mbox install instpackage instqueue instchown \
 instcheck home home+df proc proc+df binm1 binm1+df binm2 binm2+df \
@@ -883,7 +883,7 @@ qmail-queue.0 qmail-inject.0 mailsubj.0 qmail-showctl.0 qmail-newu.0 \
 qmail-pw2u.0 qmail-qread.0 qmail-qstat.0 qmail-tcpto.0 qmail-tcpok.0 \
 qmail-pop3d.0 qmail-popup.0 qmail-qmqpc.0 qmail-qmqpd.0 qmail-qmtpd.0 \
 qmail-smtpd.0 tcp-env.0 qmail-newmrh.0 qreceipt.0 qbiff.0 forward.0 \
-qmail-rcptcheck-realrcptto.0 \
+qmail-rcptcheck.0 qmail-rcptcheck-realrcptto.0 \
 preline.0 condredirect.0 bouncesaying.0 except.0 maildirmake.0 \
 maildir2mbox.0 qmail.0 qmail-limits.0 qmail-log.0 \
 qmail-control.0 qmail-header.0 qmail-users.0 dot-qmail.0 \
@@ -1354,6 +1354,22 @@ compile qmail-queue.c readwrite.h sig.h exit.h open.h seek.h fmt.h \
 alloc.h substdio.h datetime.h now.h datetime.h triggerpull.h extra.h \
 uidgid.h auto_qmail.h auto_uids.h auto_users.h date822fmt.h fmtqfn.h
 	./compile qmail-queue.c
+
+qmail-rcptcheck: \
+load qmail-rcptcheck.o control.o env.a error.a fs.a getln.a open.a \
+stralloc.a substdio.a str.a wait.a
+	./load qmail-rcptcheck control.o env.a error.a fs.a getln.a open.a \
+	stralloc.a substdio.a str.a wait.a
+
+qmail-rcptcheck.o: \
+compile qmail-rcptcheck.c control.h env.h stralloc.h substdio.h wait.h
+	./compile qmail-rcptcheck.c
+
+qmail-rcptcheck.8: \
+qmail-rcptcheck.9 conf-qmail
+	cat qmail-rcptcheck.9 \
+	| sed s}QMAILHOME}"`head -n 1 conf-qmail`"}g \
+	> qmail-rcptcheck.8
 
 qmail-rcptcheck-realrcptto: \
 load qmail-rcptcheck-realrcptto.o realrcptto.o auto_break.o \

--- a/TARGETS
+++ b/TARGETS
@@ -380,3 +380,7 @@ qmail-rcptcheck-realrcptto.8
 qmail-rcptcheck-realrcptto.0
 qmail-rcptcheck-realrcptto.o
 qmail-rcptcheck-realrcptto
+qmail-rcptcheck.8
+qmail-rcptcheck.0
+qmail-rcptcheck.o
+qmail-rcptcheck

--- a/TARGETS
+++ b/TARGETS
@@ -376,3 +376,7 @@ setup
 qtmp.h
 qmail-send.service
 realrcptto.o
+qmail-rcptcheck-realrcptto.8
+qmail-rcptcheck-realrcptto.0
+qmail-rcptcheck-realrcptto.o
+qmail-rcptcheck-realrcptto

--- a/TARGETS
+++ b/TARGETS
@@ -375,3 +375,4 @@ forgeries.0
 setup
 qtmp.h
 qmail-send.service
+realrcptto.o

--- a/hier.c
+++ b/hier.c
@@ -137,6 +137,8 @@ void hier()
   c(auto_qmail,"bin","tcp-env",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","qreceipt",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","qbiff",auto_uido,auto_gidq,0755);
+  c(auto_qmail,"bin","qmail-rcptcheck",auto_uido,auto_gidq,0755);
+  c(auto_qmail,"bin","qmail-rcptcheck-realrcptto",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","forward",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","preline",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","condredirect",auto_uido,auto_gidq,0755);
@@ -144,7 +146,6 @@ void hier()
   c(auto_qmail,"bin","except",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","maildirmake",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","maildir2mbox",auto_uido,auto_gidq,0755);
-  c(auto_qmail,"bin","qmail-rcptcheck-realrcptto",auto_uido,auto_gidq,0755);
 
   c(auto_qmail,"man/man5","addresses.5",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/cat5","addresses.0",auto_uido,auto_gidq,0644);
@@ -249,6 +250,8 @@ void hier()
   c(auto_qmail,"man/cat8","qmail-smtpd.0",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/man8","qmail-command.8",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/cat8","qmail-command.0",auto_uido,auto_gidq,0644);
+  c(auto_qmail,"man/man8","qmail-rcptcheck.8",auto_uido,auto_gidq,0644);
+  c(auto_qmail,"man/cat8","qmail-rcptcheck.0",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/man8","qmail-rcptcheck-realrcptto.8",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/cat8","qmail-rcptcheck-realrcptto.0",auto_uido,auto_gidq,0644);
 }

--- a/hier.c
+++ b/hier.c
@@ -144,6 +144,7 @@ void hier()
   c(auto_qmail,"bin","except",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","maildirmake",auto_uido,auto_gidq,0755);
   c(auto_qmail,"bin","maildir2mbox",auto_uido,auto_gidq,0755);
+  c(auto_qmail,"bin","qmail-rcptcheck-realrcptto",auto_uido,auto_gidq,0755);
 
   c(auto_qmail,"man/man5","addresses.5",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/cat5","addresses.0",auto_uido,auto_gidq,0644);
@@ -248,4 +249,6 @@ void hier()
   c(auto_qmail,"man/cat8","qmail-smtpd.0",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/man8","qmail-command.8",auto_uido,auto_gidq,0644);
   c(auto_qmail,"man/cat8","qmail-command.0",auto_uido,auto_gidq,0644);
+  c(auto_qmail,"man/man8","qmail-rcptcheck-realrcptto.8",auto_uido,auto_gidq,0644);
+  c(auto_qmail,"man/cat8","qmail-rcptcheck-realrcptto.0",auto_uido,auto_gidq,0644);
 }

--- a/qmail-qmtpd.c
+++ b/qmail-qmtpd.c
@@ -17,16 +17,7 @@
 
 void _noreturn_ badproto() { _exit(100); }
 void _noreturn_ resources() { _exit(111); }
-void die_nomem() { resources(); }
-void die_control() { resources(); }
-void die_cdb() { resources(); }
-void die_sys() { resources(); }
 
-extern void realrcptto_init();
-extern void realrcptto_start();
-extern int realrcptto();
-extern int realrcptto_deny();
- 
 ssize_t safewrite(int fd, const void *buf, size_t len)
 {
   ssize_t r;
@@ -111,8 +102,6 @@ main()
   if (rcpthosts_init() == -1) resources();
   relayclient = env_get("RELAYCLIENT");
   relayclientlen = relayclient ? str_len(relayclient) : 0;
-
-  realrcptto_init();
  
   if (control_readint(&databytes,"control/databytes") == -1) resources();
   x = env_get("DATABYTES");
@@ -129,7 +118,6 @@ main()
   if (!local) local = "unknown";
  
   for (;;) {
-    realrcptto_start();
     if (!stralloc_copys(&failure,"")) resources();
     flagsenderok = 1;
  
@@ -232,10 +220,6 @@ main()
             case -1: resources();
             case 0: failure.s[failure.len - 1] = 'D';
           }
-
-        if (!failure.s[failure.len - 1])
-          if (!realrcptto(buf))
-            failure.s[failure.len - 1] = 'D';
  
         if (!failure.s[failure.len - 1]) {
           qmail_to(&qq,buf);
@@ -251,7 +235,6 @@ main()
     result = qmail_close(&qq);
     if (!flagsenderok) result = "Dunacceptable sender (#5.1.7)";
     if (databytes) if (!bytestooverflow) result = "Dsorry, that message size exceeds my databytes limit (#5.3.4)";
-    if (realrcptto_deny()) result = "Dsorry, no mailbox here by that name. (#5.1.1)\r\n";
  
     if (*result)
       len = str_len(result);

--- a/qmail-rcptcheck-realrcptto.9
+++ b/qmail-rcptcheck-realrcptto.9
@@ -8,16 +8,8 @@ qmail-rcptcheck-realrcptto \- realrcptto patch as standalone program
 is Paul Jarc's realrcptto patch repackaged as a
 .BR RCPTCHECK -compatible
 program.
-.SH EXAMPLES
-To check envelope recipients during the SMTP protocol conversation,
-rejecting any that would eventually bounce due to a missing .qmail file:
-
-.EX
-   # echo ':allow,RCPTCHECK="QMAILHOME/bin/qmail-rcptcheck-realrcptto"' >> /etc/tcp.smtp
-   # qmailctl cdb
-.EE
-
-(If you already have an :allow line, don’t add another, just extend it to define RCPTCHECK as above.)
+It can check envelope recipients during the SMTP protocol conversation,
+rejecting any that would eventually bounce due to a missing .qmail file.
 .SH ENVIRONMENT
 If
 .B QMAILRRTDENYALL
@@ -34,4 +26,6 @@ Originally adapted for rejectutils by Amitai Schleier, based on this code from P
 .PP
 .I http://code.dogmap.org/qmail/#realrcptto
 .SH "SEE ALSO"
-qmail-smtpd(8), dot-qmail(5).
+dot-qmail(5),
+qmail-rcptcheck(8),
+qmail-smtpd(8)

--- a/qmail-rcptcheck-realrcptto.9
+++ b/qmail-rcptcheck-realrcptto.9
@@ -1,0 +1,37 @@
+.TH qmail-rcptcheck-realrcptto 8
+.SH NAME
+qmail-rcptcheck-realrcptto \- realrcptto patch as standalone program
+.SH SYNOPSIS
+.B qmail-rcptcheck-realrcptto
+.SH DESCRIPTION
+.B qmail-rcptcheck-realrcptto
+is Paul Jarc's realrcptto patch repackaged as a
+.BR RCPTCHECK -compatible
+program.
+.SH EXAMPLES
+To check envelope recipients during the SMTP protocol conversation,
+rejecting any that would eventually bounce due to a missing .qmail file:
+
+.EX
+   # echo ':allow,RCPTCHECK="QMAILHOME/bin/qmail-rcptcheck-realrcptto"' >> /etc/tcp.smtp
+   # qmailctl cdb
+.EE
+
+(If you already have an :allow line, don’t add another, just extend it to define RCPTCHECK as above.)
+.SH ENVIRONMENT
+If
+.B QMAILRRTDENYALL
+is set to
+.B 1
+in the environment,
+then each individual recipient address will be accepted,
+but the whole message will be rejected,
+to stop attackers from probing for valid addresses.
+It's still possible to probe by sending empty, single-recipient messages,
+and then sending the real message with all the recipients that weren't rejected.
+.SH HISTORY
+Originally adapted for rejectutils by Amitai Schleier, based on this code from Paul Jarc:
+.PP
+.I http://code.dogmap.org/qmail/#realrcptto
+.SH "SEE ALSO"
+qmail-smtpd(8), dot-qmail(5).

--- a/qmail-rcptcheck-realrcptto.c
+++ b/qmail-rcptcheck-realrcptto.c
@@ -1,0 +1,27 @@
+#include <unistd.h>
+#include "env.h"
+#include "realrcptto.h"
+
+void accept_recipient() { _exit(  0); }
+void reject_recipient() { _exit(100); }
+void unable_to_verify() { _exit(111); }
+
+void die_cdb()     { unable_to_verify(); }
+void die_control() { unable_to_verify(); }
+void die_nomem()   { unable_to_verify(); }
+void die_sys()     { unable_to_verify(); }
+
+int main(void)
+{
+  char *recipient = env_get("RECIPIENT");
+
+  if (!recipient)
+    unable_to_verify();
+
+  realrcptto_init();
+  realrcptto_start();
+  if (!realrcptto(recipient))
+    reject_recipient();
+
+  accept_recipient();
+}

--- a/qmail-rcptcheck.9
+++ b/qmail-rcptcheck.9
@@ -1,0 +1,94 @@
+.TH qmail-rcptcheck 8
+.SH NAME
+qmail-rcptcheck \- run a sequence of sender/recipient checks
+.SH SYNOPSIS
+.B qmail-rcptcheck
+.SH DESCRIPTION
+.B qmail-rcptcheck
+runs an administrator-defined sequence of programs
+to check SMTP envelope senders and recipients.
+Checks must adhere to the
+.B RCPTCHECK
+interface.
+If any check rejects, the message is rejected.
+.PP
+.B qmail-rcptcheck
+is most commonly invoked from
+.B qmail-smtpd
+via
+.BR RCPTCHECK .
+.SH "ENVIRONMENT VARIABLES"
+Set
+.B RCPTCHECK
+to
+.I QMAILHOME/bin/qmail-rcptcheck
+in your
+.BR tcpserver 's
+tcprules (and rebuild the CDB).
+.PP
+Recipient-checking programs can inspect these variables:
+.TP 5
+.I SENDER
+Contains the envelope sender.
+.TP 5
+.I RECIPIENT
+Contains the envelope recipient.
+.SH "CONTROL FILES"
+.TP 5
+.I rcptchecks
+Sequence of checks.
+.P
+.BR RCPTCHECK -compatible
+programs must be listed one per line,
+with no arguments.
+Changing the sequence takes effect immediately, no restart required.
+If the control file is empty,
+contains only comments,
+or doesn't exist,
+messages are not rejected.
+.P
+To test your configuration, as
+.IR root ,
+in
+.IR QMAILHOME :
+.P
+# env SENDER=a RECIPIENT=b setuidgid qmaild qmail-rcptcheck; echo $?
+.SH "EXIT CODES"
+As defined by the
+.B RCPTCHECK
+interface,
+.I 120
+is reserved.
+Recipient-checking programs should exit
+.I 111
+when unable to verify,
+.I 100
+to reject, or
+any other non-reserved code to accept.
+.SH ERRORS
+Some typical SMTP errors and their likely causes:
+.TP 5
+.I "421 unable to execute recipient check (#4.3.0)"
+The control file lists a program that doesn't exist
+or otherwise can't be executed.
+.SH EXAMPLES
+To check envelope recipients during the SMTP protocol conversation,
+rejecting any that would eventually bounce due to a missing .qmail file,
+and then check any remaining recipients with rejectutils' qmail-rcptcheck-badrcptto(8):
+
+.EX
+# echo 'QMAILHOME/bin/qmail-rcptcheck-realrcptto' > QMAILHOME/control/rcptchecks
+# echo 'QMAILHOME/bin/qmail-rcptcheck-badrcptto' >> QMAILHOME/control/rcptchecks
+# echo ':allow,RCPTCHECK="QMAILHOME/bin/qmail-rcptcheck"' >> /etc/tcp.smtp
+# qmailctl cdb
+.EE
+
+(If you already have an :allow line, don't add another, just change it to define
+.B RCPTCHECK
+as above.)
+.SH HISTORY
+.B qmail-rcptcheck
+was originally written by Amitai Schleier.
+.SH "SEE ALSO"
+qmail-rcptcheck-realrcptto(8),
+qmail-smtpd(8)

--- a/qmail-rcptcheck.c
+++ b/qmail-rcptcheck.c
@@ -1,0 +1,167 @@
+#include <unistd.h>
+#include "control.h"
+#include "env.h"
+#include "stralloc.h"
+#include "substdio.h"
+#include "wait.h"
+
+static char outbuf[128];
+static struct substdio ssout = SUBSTDIO_FDBUF(write,1,outbuf,sizeof outbuf);
+static char errbuf[128];
+static struct substdio sserr = SUBSTDIO_FDBUF(write,2,errbuf,sizeof errbuf);
+
+struct rcptcheck_api {
+  char *(*get_sender)();
+  char *(*get_recipient)();
+  void (*accept_recipient)();
+  void (*reject_recipient)();
+  void (*unable_to_verify)();
+  void (*unable_to_execute)();
+} rcptcheck;
+
+static char *rcptcheck_get_sender() {
+  return env_get("SENDER");
+}
+
+static char *rcptcheck_get_recipient() {
+  return env_get("RECIPIENT");
+}
+
+static void rcptcheck_accept_recipient() {
+  _exit(0);
+}
+
+static void rcptcheck_reject_recipient() {
+  _exit(100);
+}
+
+static void rcptcheck_unable_to_verify() {
+  _exit(111);
+}
+
+static void rcptcheck_unable_to_execute() {
+  _exit(120);
+}
+
+static void run_rcptchecks_under_rcptcheck() {
+  rcptcheck.get_sender        = rcptcheck_get_sender;
+  rcptcheck.get_recipient     = rcptcheck_get_recipient;
+  rcptcheck.accept_recipient  = rcptcheck_accept_recipient;
+  rcptcheck.reject_recipient  = rcptcheck_reject_recipient;
+  rcptcheck.unable_to_verify  = rcptcheck_unable_to_verify;
+  rcptcheck.unable_to_execute = rcptcheck_unable_to_execute;
+}
+
+static void putsdie(substdio *ss,char *string) {
+  substdio_puts(ss,string);
+  substdio_flush(ss);
+  _exit(0);
+}
+
+static char *spp_get_sender() {
+  return env_get("SMTPMAILFROM");
+}
+
+static char *spp_get_recipient() {
+  return env_get("SMTPRCPTTO");
+}
+
+static void spp_accept_recipient() {
+  putsdie(&ssout,"");
+}
+
+static void spp_reject_recipient() {
+  putsdie(&ssout,"E553 sorry, no mailbox here by that name. (#5.1.1)\n");
+}
+
+static void spp_unable_to_verify() {
+  putsdie(&ssout,"R421 unable to verify recipient (#4.3.0)\n");
+}
+
+static void spp_unable_to_execute() {
+  putsdie(&ssout,"R421 unable to execute recipient check (#4.3.0)\n");
+}
+
+static void run_rcptchecks_under_spp() {
+  rcptcheck.get_sender        = spp_get_sender;
+  rcptcheck.get_recipient     = spp_get_recipient;
+  rcptcheck.accept_recipient  = spp_accept_recipient;
+  rcptcheck.reject_recipient  = spp_reject_recipient;
+  rcptcheck.unable_to_verify  = spp_unable_to_verify;
+  rcptcheck.unable_to_execute = spp_unable_to_execute;
+}
+
+static void run_rcptcheck(char *program)
+{
+  char *rcptcheck_program[2] = { program, 0 };
+  int pid;
+  int wstat;
+
+  switch(pid = fork()) {
+    case -1:
+      rcptcheck.unable_to_execute();
+    case 0:
+      execv(*rcptcheck_program,rcptcheck_program);
+      rcptcheck.unable_to_execute();
+  }
+
+  if (wait_pid(&wstat,pid) == -1)
+    rcptcheck.unable_to_execute();
+  if (wait_crashed(wstat))
+    rcptcheck.unable_to_execute();
+
+  switch(wait_exitcode(wstat)) {
+    case 100: rcptcheck.reject_recipient();
+    case 111: rcptcheck.unable_to_verify();
+    case 120: rcptcheck.unable_to_execute();
+    default:  return;
+  }
+}
+
+static int looks_like_spp() {
+  char *x = env_get("SMTPRCPTTO");
+  return (x != 0);
+}
+
+static void set_environment(char *sender, char *recipient) {
+  substdio_puts(&sserr,"qmail-rcptcheck: from ");
+
+  if (sender) {
+    substdio_puts(&sserr,sender);
+    if (!env_put2("SENDER", sender)) rcptcheck.unable_to_verify();
+  }
+
+  substdio_puts(&sserr," to ");
+
+  if (recipient) {
+    substdio_puts(&sserr,recipient);
+    if (!env_put2("RECIPIENT", recipient)) rcptcheck.unable_to_verify();
+  }
+
+  substdio_puts(&sserr,"\n");
+  substdio_flush(&sserr);
+}
+
+int main(void)
+{
+  stralloc rcptchecks = {0};
+  int linestart;
+  int pos;
+
+  if (looks_like_spp()) run_rcptchecks_under_spp();
+  else run_rcptchecks_under_rcptcheck();
+
+  set_environment(rcptcheck.get_sender(), rcptcheck.get_recipient());
+
+  if (control_readfile(&rcptchecks,"control/rcptchecks",0) == -1)
+    rcptcheck.unable_to_verify();
+
+  for (linestart = 0, pos = 0; pos < rcptchecks.len; pos++) {
+    if (rcptchecks.s[pos] == '\0') {
+      run_rcptcheck(rcptchecks.s + linestart);
+      linestart = pos + 1;
+    }
+  }
+
+  rcptcheck.accept_recipient();
+}

--- a/qmail-smtpd.8
+++ b/qmail-smtpd.8
@@ -24,6 +24,22 @@ header fields.
 
 .B qmail-smtpd
 supports ESMTP, including the 8BITMIME and PIPELINING options.
+
+If the environment variable
+.B RCPTCHECK
+is set,
+.B qmail-smtpd
+runs the specified recipient-checking program for each
+.BR "RCPT TO" .
+The program's environment contains the envelope sender and recipient in
+.B SENDER
+and
+.BR RECIPIENT ,
+respectively.
+A recipient-checking program exits 100 to reject,
+111 if unable to check,
+or anything other than 120 (most typically 0) to accept.
+
 .SH TRANSPARENCY
 .B qmail-smtpd
 converts the SMTP newline convention into the UNIX newline convention

--- a/qmail-smtpd.8
+++ b/qmail-smtpd.8
@@ -193,4 +193,4 @@ qmail-inject(8),
 qmail-newmrh(8),
 qmail-queue(8),
 qmail-remote(8),
-qmail-rcptcheck-realrcptto(8)
+qmail-rcptcheck(8)

--- a/qmail-smtpd.8
+++ b/qmail-smtpd.8
@@ -192,4 +192,5 @@ qmail-control(5),
 qmail-inject(8),
 qmail-newmrh(8),
 qmail-queue(8),
-qmail-remote(8)
+qmail-remote(8),
+qmail-rcptcheck-realrcptto(8)

--- a/qmail-smtpd.c
+++ b/qmail-smtpd.c
@@ -46,6 +46,8 @@ void die_ipme() { out("421 unable to figure out my IP addresses (#4.3.0)\r\n"); 
 void die_fork() { out("421 unable to fork (#4.3.0)\r\n"); flush(); _exit(1); }
 void die_rcpt() { out("421 unable to verify recipient (#4.3.0)\r\n"); flush(); _exit(1); }
 void die_rcpt2() { out("421 unable to execute recipient check (#4.3.0)\r\n"); flush(); _exit(1); }
+void die_cdb() { out("421 unable to read cdb user database (#4.3.0)\r\n"); flush(); _exit(1); }
+void die_sys() { out("421 unable to read system user database (#4.3.0)\r\n"); flush(); _exit(1); }
 void straynewline() { out("451 See https://cr.yp.to/docs/smtplf.html.\r\n"); flush(); _exit(1); }
 
 void err_bmf() { out("553 sorry, your envelope sender is in my badmailfrom list (#5.7.1)\r\n"); }
@@ -59,6 +61,10 @@ void err_vrfy(arg) char *arg; { out("252 send some mail, i'll try my best\r\n");
 void err_qqt() { out("451 qqt failure (#4.3.0)\r\n"); }
 void err_badrcpt() { out("553 sorry, no mailbox here by that name. (#5.1.1)\r\n"); }
 
+extern void realrcptto_init();
+extern void realrcptto_start();
+extern int realrcptto();
+extern int realrcptto_deny();
 
 stralloc greeting = {0};
 
@@ -117,6 +123,8 @@ void setup()
   if (bmfok == -1) die_control();
   if (bmfok)
     if (!constmap_init(&mapbmf,bmf.s,bmf.len,0)) die_nomem();
+
+  realrcptto_init();
  
   if (control_readint(&databytes,"control/databytes") == -1) die_control();
   x = env_get("DATABYTES");
@@ -271,6 +279,7 @@ void smtp_mail(arg) char *arg;
   if (!stralloc_copys(&rcptto,"")) die_nomem();
   if (!stralloc_copys(&mailfrom,addr.s)) die_nomem();
   if (!stralloc_0(&mailfrom)) die_nomem();
+  realrcptto_start();
   out("250 ok\r\n");
 }
 void smtp_rcpt(arg) char *arg; {
@@ -285,6 +294,10 @@ void smtp_rcpt(arg) char *arg; {
   else {
     if (!addrallowed()) { err_nogateway(); return; }
     if (!addrvalid()) { err_badrcpt(); return; }
+  }
+  if (!realrcptto(addr.s)) {
+    out("550 sorry, no mailbox here by that name. (#5.1.1)\r\n");
+    return;
   }
   if (!stralloc_cats(&rcptto,"T")) die_nomem();
   if (!stralloc_cats(&rcptto,addr.s)) die_nomem();
@@ -399,6 +412,7 @@ void smtp_data(arg) char *arg; {
  
   if (!seenmail) { err_wantmail(); return; }
   if (!rcptto.len) { err_wantrcpt(); return; }
+  if (realrcptto_deny()) { out("554 sorry, no mailbox here by that name. (#5.1.1)\r\n"); return; }
   seenmail = 0;
   if (databytes) bytestooverflow = databytes + 1;
   if (qmail_open(&qqt) == -1) { err_qqt(); return; }

--- a/realrcptto.c
+++ b/realrcptto.c
@@ -74,7 +74,7 @@ void realrcptto_init()
     case 1: if (!constmap_init(&mapvdoms,vdoms.s,vdoms.len,1)) die_nomem();
   }
 
-  str_copy(pidbuf + fmt_ulong(pidbuf,getpid())," ");
+  str_copy(pidbuf + fmt_ulong(pidbuf,getppid())," ");
   x=env_get("PROTO");
   if (x) {
     static char const remoteip[]="REMOTEIP";
@@ -104,7 +104,7 @@ void realrcptto_start()
 static int denyaddr(addr)
 char *addr;
 {
-  substdio_puts(&sserr,"realrcptto ");
+  substdio_puts(&sserr,"rcptcheck: realrcptto ");
   substdio_puts(&sserr,pidbuf);
   substdio_puts(&sserr,remoteipbuf);
   substdio_puts(&sserr,addr);

--- a/realrcptto.c
+++ b/realrcptto.c
@@ -1,0 +1,336 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <pwd.h>
+#include "auto_break.h"
+#include "auto_usera.h"
+#include "byte.h"
+#include "case.h"
+#include "cdb.h"
+#include "constmap.h"
+#include "error.h"
+#include "fmt.h"
+#include "open.h"
+#include "str.h"
+#include "stralloc.h"
+#include "uint32.h"
+#include "substdio.h"
+#include "env.h"
+
+extern void die_nomem();
+extern void die_control();
+extern void die_cdb();
+extern void die_sys();
+
+static stralloc envnoathost = {0};
+static stralloc percenthack = {0};
+static stralloc locals = {0};
+static stralloc vdoms = {0};
+static struct constmap mappercenthack;
+static struct constmap maplocals;
+static struct constmap mapvdoms;
+
+static char *dash;
+static char *extension;
+static char *local;
+static struct passwd *pw;
+
+static char errbuf[128];
+static struct substdio sserr = SUBSTDIO_FDBUF(write,2,errbuf,sizeof errbuf);
+
+static char pidbuf[64];
+static char remoteipbuf[64]=" ";
+
+static int flagdenyall;
+static int flagdenyany;
+
+void realrcptto_init()
+{
+  char *x;
+
+  if (control_rldef(&envnoathost,"control/envnoathost",1,"envnoathost") != 1)
+    die_control();
+
+  if (control_readfile(&locals,"control/locals",1) != 1) die_control();
+  if (!constmap_init(&maplocals,locals.s,locals.len,0)) die_nomem();
+  switch(control_readfile(&percenthack,"control/percenthack",0)) {
+    case -1: die_control();
+    case 0: if (!constmap_init(&mappercenthack,"",0,0)) die_nomem();
+    case 1:
+      if (!constmap_init(&mappercenthack,percenthack.s,percenthack.len,0))
+        die_nomem();
+  }
+  switch(control_readfile(&vdoms,"control/virtualdomains",0)) {
+    case -1: die_control();
+    case 0: if (!constmap_init(&mapvdoms,"",0,1)) die_nomem();
+    case 1: if (!constmap_init(&mapvdoms,vdoms.s,vdoms.len,1)) die_nomem();
+  }
+
+  str_copy(pidbuf + fmt_ulong(pidbuf,getpid())," ");
+  x=env_get("PROTO");
+  if (x) {
+    static char const remoteip[]="REMOTEIP";
+    unsigned int len = str_len(x);
+    if (len <= sizeof remoteipbuf - sizeof remoteip) {
+      byte_copy(remoteipbuf,len,x);
+      byte_copy(remoteipbuf + len,sizeof remoteip,remoteip);
+      x = env_get(remoteipbuf);
+      len = str_len(x);
+      if (len + 1 < sizeof remoteipbuf) {
+        byte_copy(remoteipbuf,len,x);
+        remoteipbuf[len]=' ';
+        remoteipbuf[len + 1]='\0';
+      }
+    }
+  }
+
+  x = env_get("QMAILRRTDENYALL");
+  flagdenyall = (x && x[0]=='1' && x[1]=='\0');
+}
+
+void realrcptto_start()
+{
+  flagdenyany = 0;
+}
+
+static int denyaddr(addr)
+char *addr;
+{
+  substdio_puts(&sserr,"realrcptto ");
+  substdio_puts(&sserr,pidbuf);
+  substdio_puts(&sserr,remoteipbuf);
+  substdio_puts(&sserr,addr);
+  substdio_puts(&sserr,"\n");
+  substdio_flush(&sserr);
+  flagdenyany = 1;
+  return flagdenyall;
+}
+
+static void stat_error(path,error)
+char* path;
+int error;
+{
+  substdio_puts(&sserr,"unable to stat ");
+  substdio_puts(&sserr,path);
+  substdio_puts(&sserr,": ");
+  substdio_puts(&sserr,error_str(error));
+  substdio_puts(&sserr,"\n");
+  substdio_flush(&sserr);
+}
+
+#define GETPW_USERLEN 32
+
+static int userext()
+{
+  char username[GETPW_USERLEN];
+  struct stat st;
+
+  extension = local + str_len(local);
+  for (;;) {
+    if (extension - local < sizeof(username))
+      if (!*extension || (*extension == *auto_break)) {
+	byte_copy(username,extension - local,local);
+	username[extension - local] = 0;
+	case_lowers(username);
+	errno = 0;
+	pw = getpwnam(username);
+	if (errno == error_txtbsy) die_sys();
+	if (pw)
+	  if (pw->pw_uid)
+	    if (stat(pw->pw_dir,&st) == 0) {
+	      if (st.st_uid == pw->pw_uid) {
+		dash = "";
+		if (*extension) { ++extension; dash = "-"; }
+		return 1;
+	      }
+	    }
+	    else
+	      if (error_temp(errno)) die_sys();
+      }
+    if (extension == local) return 0;
+    --extension;
+  }
+}
+
+int realrcptto(addr)
+char *addr;
+{
+  char *homedir;
+  static stralloc localpart = {0};
+  static stralloc lower = {0};
+  static stralloc nughde = {0};
+  static stralloc wildchars = {0};
+  static stralloc safeext = {0};
+  static stralloc qme = {0};
+  unsigned int i,at;
+
+  /* Short circuit, or full logging?  Short circuit. */
+  if (flagdenyall && flagdenyany) return 1;
+
+  /* qmail-send:rewrite */
+  if (!stralloc_copys(&localpart,addr)) die_nomem();
+  i = byte_rchr(localpart.s,localpart.len,'@');
+  if (i == localpart.len) {
+    if (!stralloc_cats(&localpart,"@")) die_nomem();
+    if (!stralloc_cat(&localpart,&envnoathost)) die_nomem();
+  }
+  while (constmap(&mappercenthack,localpart.s + i + 1,localpart.len - i - 1)) {
+    unsigned int j = byte_rchr(localpart.s,i,'%');
+    if (j == i) break;
+    localpart.len = i;
+    i = j;
+    localpart.s[i] = '@';
+  }
+  at = byte_rchr(localpart.s,localpart.len,'@');
+  if (constmap(&maplocals,localpart.s + at + 1,localpart.len - at - 1)) {
+    localpart.len = at;
+    localpart.s[at] = '\0';
+  } else {
+    unsigned int xlen,newlen;
+    char *x;
+    for (i = 0;;++i) {
+      if (i > localpart.len) return 1;
+      if (!i || (i == at + 1) || (i == localpart.len) ||
+          ((i > at) && (localpart.s[i] == '.'))) {
+        x = constmap(&mapvdoms,localpart.s + i,localpart.len - i);
+        if (x) break;
+      }
+    }
+    if (!*x) return 1;
+    xlen = str_len(x) + 1;  /* +1 for '-' */
+    newlen = xlen + at + 1; /* +1 for \0 */
+    if (xlen < 1 || newlen - 1 < xlen || newlen < 1 ||
+        !stralloc_ready(&localpart,newlen))
+      die_nomem();
+    localpart.s[newlen - 1] = '\0';
+    byte_copyr(localpart.s + xlen,at,localpart.s);
+    localpart.s[xlen - 1] = '-';
+    byte_copy(localpart.s,xlen - 1,x);
+    localpart.len = newlen;
+  }
+
+  /* qmail-lspawn:nughde_get */
+  {
+    int r,fd,flagwild;
+    if (!stralloc_copys(&lower,"!")) die_nomem();
+    if (!stralloc_cats(&lower,localpart.s)) die_nomem();
+    if (!stralloc_0(&lower)) die_nomem();
+    case_lowerb(lower.s,lower.len);
+    if (!stralloc_copys(&nughde,"")) die_nomem();
+    fd = open_read("users/cdb");
+    if (fd == -1) {
+      if (errno != error_noent) die_cdb();
+    } else {
+      uint32 dlen;
+      r = cdb_seek(fd,"",0,&dlen);
+      if (r != 1) die_cdb();
+      if (!stralloc_ready(&wildchars,(unsigned int) dlen)) die_nomem();
+      wildchars.len = dlen;
+      if (cdb_bread(fd,wildchars.s,wildchars.len) == -1) die_cdb();
+      i = lower.len;
+      flagwild = 0;
+      do { /* i > 0 */
+        if (!flagwild || (i == 1) ||
+            (byte_chr(wildchars.s,wildchars.len,lower.s[i - 1])
+             < wildchars.len)) {
+          r = cdb_seek(fd,lower.s,i,&dlen);
+          if (r == -1) die_cdb();
+          if (r == 1) {
+            char *x;
+            if (!stralloc_ready(&nughde,(unsigned int) dlen)) die_nomem();
+            nughde.len = dlen;
+            if (cdb_bread(fd,nughde.s,nughde.len) == -1) die_cdb();
+            if (flagwild)
+              if (!stralloc_cats(&nughde,localpart.s + i - 1)) die_nomem();
+            if (!stralloc_0(&nughde)) die_nomem();
+            close(fd);
+            x=nughde.s;
+            /* skip username */
+            x += byte_chr(x,nughde.s + nughde.len - x,'\0');
+            if (x == nughde.s + nughde.len) return 1;
+            ++x;
+            /* skip uid */
+            x += byte_chr(x,nughde.s + nughde.len - x,'\0');
+            if (x == nughde.s + nughde.len) return 1;
+            ++x;
+            /* skip gid */
+            x += byte_chr(x,nughde.s + nughde.len - x,'\0');
+            if (x == nughde.s + nughde.len) return 1;
+            ++x;
+            /* skip homedir */
+            homedir=x;
+            x += byte_chr(x,nughde.s + nughde.len - x,'\0');
+            if (x == nughde.s + nughde.len) return 1;
+            ++x;
+            /* skip dash */
+            dash=x;
+            x += byte_chr(x,nughde.s + nughde.len - x,'\0');
+            if (x == nughde.s + nughde.len) return 1;
+            ++x;
+            extension=x;
+            goto got_nughde;
+          }
+        }
+        --i;
+        flagwild = 1;
+      } while (i);
+      close(fd);
+    }
+  }
+
+  /* qmail-getpw */
+  local = localpart.s;
+  if (!userext()) {
+    extension = local;
+    dash = "-";
+    pw = getpwnam(auto_usera);
+  }
+  if (!pw) return denyaddr(addr);
+  if (!stralloc_copys(&nughde,pw->pw_dir)) die_nomem();
+  if (!stralloc_0(&nughde)) die_nomem();
+  homedir=nughde.s;
+
+  got_nughde:
+
+  /* qmail-local:qmesearch */
+  if (!*dash) return 1;
+  if (!stralloc_copys(&safeext,extension)) die_nomem();
+  case_lowerb(safeext.s,safeext.len);
+  for (i = 0;i < safeext.len;++i)
+    if (safeext.s[i] == '.')
+      safeext.s[i] = ':';
+  {
+    struct stat st;
+    int i;
+    if (!stralloc_copys(&qme,homedir)) die_nomem();
+    if (!stralloc_cats(&qme,"/.qmail")) die_nomem();
+    if (!stralloc_cats(&qme,dash)) die_nomem();
+    if (!stralloc_cat(&qme,&safeext)) die_nomem();
+    if (!stralloc_0(&qme)) die_nomem();
+    if (stat(qme.s,&st) == 0) return 1;
+    if (errno != error_noent) {
+      stat_error(qme.s,errno);
+      return 1;
+    }
+    for (i = safeext.len;i >= 0;--i)
+      if (!i || (safeext.s[i - 1] == '-')) {
+        if (!stralloc_copys(&qme,homedir)) die_nomem();
+        if (!stralloc_cats(&qme,"/.qmail")) die_nomem();
+        if (!stralloc_cats(&qme,dash)) die_nomem();
+        if (!stralloc_catb(&qme,safeext.s,i)) die_nomem();
+        if (!stralloc_cats(&qme,"default")) die_nomem();
+        if (!stralloc_0(&qme)) die_nomem();
+        if (stat(qme.s,&st) == 0) return 1;
+        if (errno != error_noent) {
+          stat_error(qme.s,errno);
+          return 1;
+        }
+      }
+    return denyaddr(addr);
+  }
+}
+
+int realrcptto_deny()
+{
+  return flagdenyall && flagdenyany;
+}

--- a/realrcptto.h
+++ b/realrcptto.h
@@ -1,0 +1,9 @@
+#ifndef REALRCPTTO_H
+#define REALRCPTTO_H
+
+void realrcptto_init();
+void realrcptto_start();
+int realrcptto(char *);
+int realrcptto_deny();
+
+#endif


### PR DESCRIPTION
Give mail admins some basic SMTP recipient-checking tools:

1. An API for external programs to reject recipients (@jaysoffian's RCPTCHECK patch)
2. A program that calls the API _and_ provides the API, giving a way to list a sequence of recipient-checkers in `control/rcptchecks` (my `qmail-rcptcheck` program)
3. One such recipient-checker that requires no configuration of its own (my `qmail-rcptcheck-realrcptto`, derived from Paul Jarc's qmail-realrcptto patch)

Notably not included:

- Any other recipient-checkers, such as `qmail-rcptcheck-badrcptto` (the badrcptto patch is GPL'd, I've emailed the author) or `qmail-rcptcheck-qregex` (never needed it myself) or something for vpopmail users
- Enabling any of this by default (we probably should, in some future release)
- Adapting RCPTCHECK to `qmail-qmtpd` (probably straightforward, just needs someone who cares)
- Automated tests (I've run the code in production for years; still, sorry about this, and happy to add tests later)
- All the other programmability of [qmail-spp](http://qmail-spp.sourceforge.net) (but `qmail-rcptcheck` will happily run in that environment and recipient-checkers won't need to change at all)