### PR TITLE
qmail-qstat: simplify the code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1324,11 +1324,9 @@ exit.h
 	./compile qmail-qread.c
 
 qmail-qstat: \
-warn-auto.sh qmail-qstat.sh conf-qmail conf-break conf-split
+warn-auto.sh qmail-qstat.sh conf-qmail
 	cat warn-auto.sh qmail-qstat.sh \
 	| sed s}QMAIL}"`head -n 1 conf-qmail`"}g \
-	| sed s}BREAK}"`head -n 1 conf-break`"}g \
-	| sed s}SPLIT}"`head -n 1 conf-split`"}g \
 	> qmail-qstat
 	chmod 755 qmail-qstat
 

--- a/qmail-qstat.sh
+++ b/qmail-qstat.sh
@@ -1,7 +1,4 @@
-cd QMAIL
-messdirs=`echo queue/mess/* | wc -w`
-messfiles=`find queue/mess/* -print | wc -w`
-tododirs=`echo queue/todo | wc -w`
-todofiles=`find queue/todo -print | wc -w`
-echo messages in queue: `expr $messfiles - $messdirs`
-echo messages in queue but not yet preprocessed: `expr $todofiles - $tododirs`
+messfiles=`find QMAIL/queue/mess/* -type f | wc -l`
+todofiles=`find QMAIL/queue/todo -type f | wc -l`
+echo "messages in queue:" $messfiles
+echo "messages in queue but not yet preprocessed:" $todofiles


### PR DESCRIPTION
See the commits for a detailed description, but boils down to:

* avoid needless dependencies in Makefile
* use ```find -type f``` to just count files and avoid much complication in the script