### PR TITLE
add missing headers for some system functions

### DIFF
--- a/control.c
+++ b/control.c
@@ -1,5 +1,6 @@
 #include "control.h"
 
+#include <unistd.h>
 #include "readwrite.h"
 #include "open.h"
 #include "getln.h"

--- a/instcheck.c
+++ b/instcheck.c
@@ -1,6 +1,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string.h>
+#include <unistd.h>
 #include "strerr.h"
 #include "error.h"
 #include "readwrite.h"

--- a/maildir2mbox.c
+++ b/maildir2mbox.c
@@ -1,4 +1,5 @@
 #include <sys/stat.h>
+#include <unistd.h>
 #include "readwrite.h"
 #include "prioq.h"
 #include "env.h"

--- a/predate.c
+++ b/predate.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <time.h>
+#include <unistd.h>
 #include "datetime.h"
 #include "fork.h"
 #include "wait.h"

--- a/preline.c
+++ b/preline.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "fd.h"
 #include "sgetopt.h"
 #include "readwrite.h"

--- a/qbiff.c
+++ b/qbiff.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "qtmp.h"
 #include "readwrite.h"
 #include "stralloc.h"

--- a/qmail-clean.c
+++ b/qmail-clean.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "readwrite.h"
 #include "sig.h"
 #include "now.h"

--- a/qmail-inject.c
+++ b/qmail-inject.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "sig.h"
 #include "substdio.h"
 #include "stralloc.h"

--- a/qmail-local.c
+++ b/qmail-local.c
@@ -1,6 +1,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include "readwrite.h"
 #include "sig.h"
 #include "env.h"

--- a/qmail-lspawn.c
+++ b/qmail-lspawn.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "fd.h"
 #include "spawn.h"
 #include "wait.h"

--- a/qmail-newmrh.c
+++ b/qmail-newmrh.c
@@ -1,4 +1,5 @@
 #include <sys/stat.h>
+#include <unistd.h>
 #include "case.h"
 #include "strerr.h"
 #include "stralloc.h"

--- a/qmail-newu.c
+++ b/qmail-newu.c
@@ -1,4 +1,5 @@
 #include <sys/stat.h>
+#include <unistd.h>
 #include "stralloc.h"
 #include "subfd.h"
 #include "getln.h"

--- a/qmail-popup.c
+++ b/qmail-popup.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "commands.h"
 #include "fd.h"
 #include "sig.h"

--- a/qmail-pw2u.c
+++ b/qmail-pw2u.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "byte.h"
 #include "substdio.h"
 #include "readwrite.h"

--- a/qmail-qmqpc.c
+++ b/qmail-qmqpc.c
@@ -2,6 +2,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <unistd.h>
 #include "substdio.h"
 #include "getln.h"
 #include "readwrite.h"

--- a/qmail-qmqpd.c
+++ b/qmail-qmqpd.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "auto_qmail.h"
 #include "qmail.h"
 #include "received.h"

--- a/qmail-qmtpd.c
+++ b/qmail-qmtpd.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "stralloc.h"
 #include "substdio.h"
 #include "qmail.h"

--- a/qmail-qread.c
+++ b/qmail-qread.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "stralloc.h"
 #include "substdio.h"
 #include "subfd.h"

--- a/qmail-queue.c
+++ b/qmail-queue.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "readwrite.h"
 #include "sig.h"
 #include "exit.h"

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -2,6 +2,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <unistd.h>
 #include "sig.h"
 #include "stralloc.h"
 #include "substdio.h"

--- a/qmail-send.c
+++ b/qmail-send.c
@@ -1,6 +1,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <unistd.h>
 #include "readwrite.h"
 #include "sig.h"
 #include "direntry.h"

--- a/qmail-showctl.c
+++ b/qmail-showctl.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "substdio.h"
 #include "subfd.h"
 #include "exit.h"

--- a/qmail-smtpd.c
+++ b/qmail-smtpd.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "sig.h"
 #include "readwrite.h"
 #include "stralloc.h"

--- a/qmail-start.c
+++ b/qmail-start.c
@@ -1,4 +1,5 @@
 #include <sys/stat.h>
+#include <unistd.h>
 #include "fd.h"
 #include "prot.h"
 #include "exit.h"

--- a/qmail-tcpok.c
+++ b/qmail-tcpok.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "strerr.h"
 #include "substdio.h"
 #include "lock.h"

--- a/qmail-tcpto.c
+++ b/qmail-tcpto.c
@@ -1,4 +1,5 @@
 /* XXX: this program knows quite a bit about tcpto's internals */
+#include <unistd.h>
 
 #include "substdio.h"
 #include "subfd.h"

--- a/qmail.c
+++ b/qmail.c
@@ -1,5 +1,6 @@
 #include "qmail.h"
 
+#include <unistd.h>
 #include "substdio.h"
 #include "readwrite.h"
 #include "wait.h"

--- a/sendmail.c
+++ b/sendmail.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include "sgetopt.h"
 #include "substdio.h"
 #include "subfd.h"

--- a/slurpclose.c
+++ b/slurpclose.c
@@ -1,5 +1,6 @@
 #include "slurpclose.h"
 
+#include <unistd.h>
 #include "stralloc.h"
 #include "readwrite.h"
 #include "error.h"

--- a/spawn.c
+++ b/spawn.c
@@ -2,6 +2,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include "sig.h"
 #include "wait.h"
 #include "substdio.h"

--- a/tcpto.c
+++ b/tcpto.c
@@ -1,5 +1,6 @@
 #include "tcpto.h"
 
+#include <unistd.h>
 #include "open.h"
 #include "lock.h"
 #include "seek.h"

--- a/tcpto_clean.c
+++ b/tcpto_clean.c
@@ -1,4 +1,6 @@
 #include "tcpto.h"
+
+#include <unistd.h>
 #include "open.h"
 #include "substdio.h"
 #include "readwrite.h"


### PR DESCRIPTION
This has been split out of #65. The commit about headers for ```umask()``` has been omitted as ```mode_t``` is not used, so ```<sys/types.h>``` isn't actually needed anywhere for this.