### PR TITLE
CI: update GitHub actions to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ubuntu-latest, macos-latest]
+        host: [ubuntu-22.04, macos-latest]
         config:
          - {
            name: gcc-default,
@@ -67,14 +67,13 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: test_deps
       run: |
         if [ "${OS}" = "macos-latest" ]; then
           brew install check
         else
-          sudo sh -c 'echo "deb http://azure.archive.ubuntu.com/ubuntu hirsute universe" >> /etc/apt/sources.list'
           sudo apt-get update
           sudo apt-get install check
         fi

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Test in solaris
       id: test
-      uses: vmactions/solaris-vm@v0.0.5
+      uses: vmactions/solaris-vm@v0
       with:
         envs: 'CFLAGS NROFF LIBCHECK_VERSION'
         prepare: |


### PR DESCRIPTION
This already includes a newer version of check, and the mirror used no longer has hirsute available, so CI builds are currently failing.

While at it bump the version of the checkout action.