### PR TITLE
Correctness: Reject non-numeral netstring lengths in qmtpd and qmqpd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+- 20221019 code: netstring parsing in qmail-qmtpd & qmail-qmqpd now
+           checks that the netstring length is actually a number.
 - 20210122 code: remove register storage class declaration from codebase.
 - 20201224 bug: in qmail-remote, handle DNS packets up to max EDNS
            response size.

--- a/qmail-qmqpd.c
+++ b/qmail-qmqpd.c
@@ -13,6 +13,7 @@
 #include "str.h"
 
 void resources() { _exit(111); }
+void badproto() { _exit(100); }
 
 ssize_t safewrite(int fd, const void *buf, size_t len)
 {
@@ -52,6 +53,7 @@ unsigned long getlen()
     getbyte(&ch);
     if (ch == ':') return len;
     if (len > 200000000) resources();
+    if (ch < '0' || ch > '9') badproto();
     len = 10 * len + (ch - '0');
   }
 }

--- a/qmail-qmtpd.c
+++ b/qmail-qmtpd.c
@@ -50,6 +50,7 @@ unsigned long getlen()
     substdio_get(&ssin,&ch,1);
     if (ch == ':') return len;
     if (len > 200000000) resources();
+    if (ch < '0' || ch > '9') badproto();
     len = 10 * len + (ch - '0');
   }
 }


### PR DESCRIPTION
This was discussed on IRC between myself and a few other people back in September, and I finally got around to doing it recently. Logs can be added to the ticket upon request.