### PR TITLE
tests: fix return type read() and write() replacement stubs

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: test_deps
       run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Test in OpenBSD
       id: test

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Test in Solaris
       id: test

--- a/tests/unittest_qmail-remote.c
+++ b/tests/unittest_qmail-remote.c
@@ -14,7 +14,7 @@ static const char *writeexpect;
 static size_t readoffs;
 static size_t writeoffs;
 
-int readstub(int fd, char *buf, int len)
+ssize_t readstub(int fd, char *buf, size_t len)
 {
   size_t inlen = strlen(readexpect) - readoffs;
 
@@ -32,7 +32,7 @@ int readstub(int fd, char *buf, int len)
   return inlen;
 }
 
-int writestub(int fd, const char *buf, int len)
+ssize_t writestub(int fd, const char *buf, size_t len)
 {
   size_t outlen = strlen(writeexpect) - writeoffs;
 


### PR DESCRIPTION
Detected by build breakage with FreeBSD 14 CI.