### PR TITLE
tests: fix array sorting on big endian 64 bit

### DIFF
--- a/tests/unittest_prioq.c
+++ b/tests/unittest_prioq.c
@@ -101,7 +101,7 @@ START_TEST(test_prioq_insert_high_priority_to_low)
 END_TEST
 
 static int compare(const void *a, const void *b) {
-  return (*(int*)a - *(int*)b);
+  return (*(unsigned long*)a - *(unsigned long*)b);
 }
 
 START_TEST(test_prioq_insert_all_same_priority)


### PR DESCRIPTION
The array elements are unsigned long, i.e. 64 bit on such arches. When casting them to int only the lower half would be compared, which doesn't matter on 32 bit arches or little endian, but fails on 64 bit BE as s390 or sparc.