### PR TITLE
Don't generate empty catpages by mistake.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,20 @@ default: it
 .SUFFIXES: .0 .1 .5 .7 .8
 
 .1.0:
-	$(NROFF) -man $< >$@
+	$(NROFF) -man $< >$@; \
+	ret=$$?; [ 0 = $$ret ] || rm -f $@; exit $$ret
 
 .5.0:
-	$(NROFF) -man $< >$@
+	$(NROFF) -man $< >$@; \
+	ret=$$?; [ 0 = $$ret ] || rm -f $@; exit $$ret
 
 .7.0:
-	$(NROFF) -man $< >$@
+	$(NROFF) -man $< >$@; \
+	ret=$$?; [ 0 = $$ret ] || rm -f $@; exit $$ret
 
 .8.0:
-	$(NROFF) -man $< >$@
+	$(NROFF) -man $< >$@; \
+	ret=$$?; [ 0 = $$ret ] || rm -f $@; exit $$ret
 
 addresses.0: \
 addresses.5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build status](https://github.com/notqmail/notqmail/actions/workflows/platform-builders.yml/badge.svg)
+[![Build status](https://img.shields.io/github/actions/workflow/status/notqmail/notqmail/platform-builders.yml)](https://github.com/notqmail/notqmail/actions/workflows/platform-builders.yml?query=branch%3Amaster)
 
 # notqmail 1.08
 


### PR DESCRIPTION
We have a mechanism for not installing preformatted manpages: pass `NROFF=true` on the `make` command line, thereby generating `.0` files that are empty, which are then intentionally ignored by the installer.

We currently also generate empty `.0` files in the case where the default or overridden `NROFF` command is not found (or has a runtime error), so the `man` target appears to succeed and the resulting installation lacks the expected catpages.