### PR TITLE
merge to non-master to test autobuilds (again)

### DIFF
--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -1,17 +1,11 @@
 name: Build
 
 on:
-  push:
-    branches: ['**', '!master']
-  pull_request_target:
-    branches: ['master']
-    types:
-      - closed
+  push
 
 jobs:
 
   alpine:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       Alpine
       ${{ matrix.osversion }}
@@ -43,7 +37,6 @@ jobs:
         make -j 2 test
 
   freebsd:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       FreeBSD
       ${{ matrix.osversion }}
@@ -92,7 +85,6 @@ jobs:
           make setup check
 
   macos:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       macOS
       ${{ matrix.osversion }}
@@ -124,7 +116,6 @@ jobs:
         make -j 2 test
 
   netbsd:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       NetBSD
       ${{ matrix.osversion }}
@@ -157,7 +148,6 @@ jobs:
           make -j 2 test
 
   openbsd:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       OpenBSD
       ${{ matrix.osversion }}
@@ -190,7 +180,6 @@ jobs:
           make -j 2 test
 
   solaris:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       Solaris
       ${{ matrix.osversion }}
@@ -231,7 +220,6 @@ jobs:
           make test
 
   ubuntu:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       Ubuntu
       ${{ matrix.osversion }}


### PR DESCRIPTION
I *may* have overengineered the trigger criteria in #253. (Shock horror!)

One negative outcome: the autobuilds are never getting run on `master` itself. When we merge a PR, the autobuilds are run once more, but on the _source_ branch. So the typical GitHub build-status badge I added to the README shows seemingly indeterminate results (maybe it just shows whichever branch ran tests most recently?). And if you look for recent builds on `master`, [you get no results](https://github.com/notqmail/notqmail/actions/workflows/platform-builders.yml?query=branch%3Amaster).

To fix the job list and the new badge, I'm testing a new hypothesis: when merging, the target branch receives a 'push', that's all the trigger we need in our autobuilds, and pull requests against `master` don't need special treatment beyond the branch protection rules already in place for `master`.

To test, I'll merge to the `splunge` branch.