### PR TITLE
Simply triggering builds on push is sufficient.

### DIFF
--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -1,17 +1,11 @@
 name: Build
 
 on:
-  push:
-    branches: ['**', '!master']
-  pull_request_target:
-    branches: ['master']
-    types:
-      - closed
+  push
 
 jobs:
 
   alpine:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       Alpine
       ${{ matrix.osversion }}
@@ -43,7 +37,6 @@ jobs:
         make -j 2 test
 
   freebsd:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       FreeBSD
       ${{ matrix.osversion }}
@@ -92,7 +85,6 @@ jobs:
           make setup check
 
   macos:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       macOS
       ${{ matrix.osversion }}
@@ -124,7 +116,6 @@ jobs:
         make -j 2 test
 
   netbsd:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       NetBSD
       ${{ matrix.osversion }}
@@ -157,7 +148,6 @@ jobs:
           make -j 2 test
 
   openbsd:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       OpenBSD
       ${{ matrix.osversion }}
@@ -190,7 +180,6 @@ jobs:
           make -j 2 test
 
   solaris:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       Solaris
       ${{ matrix.osversion }}
@@ -231,7 +220,6 @@ jobs:
           make test
 
   ubuntu:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     name: >
       Ubuntu
       ${{ matrix.osversion }}


### PR DESCRIPTION
We expect merging a PR to run autobuilds on the target branch (e.g., master). The recent autobuild improvements caused a regression here: merging a PR has lately been running autobuilds on the *source* branch. So GitHub has no information to offer about build status on master, which also confounds the status badge recently added to README.md.

As we suspected, I had overengineered the trigger constraints. Merging a PR causes the target branch to receive a push, we don't need to treat any branches (or PRs!) specially in autobuilds, and the branch protection rules already in place for master -- together with running builds on every branch push -- are sufficient for PR merges to be as safe as they've always been.

See #257 (and [the workflow runs on merge to `splunge` branch](https://github.com/notqmail/notqmail/actions?query=branch%3Asplunge)) for a test of this change.