### PR TITLE
Add macOS 14 (aarch64) and 13 to the matrix.

### DIFF
--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -97,11 +97,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osversion: ["12", "11"]
+        osversion: ["14", "13", "12", "11"]
         abi: [64]
         warnings: ["-Wall -Wshadow -Werror=implicit-function-declaration -Werror=incompatible-library-redeclaration -Werror=parentheses -Werror=dangling-else -Werror=pointer-sign"]
         cc: ["clang"]
-        nroff: ["nroff", "no-roff"]
+        nroff: ["mandoc", "no-roff"]
         utmp: ["autoselect", "force-old-utmp"]
     steps:
     - name: Checkout


### PR DESCRIPTION
GitHub [just added a macOS/aarch64 runner](https://github.blog/changelog/). Also, I missed previously that macOS 13 was available. Add both.