### PR TITLE
autobuilds: speed up Solaris, add DragonFly

### DIFF
--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -36,6 +36,37 @@ jobs:
         make -j 2 it man NROFF=${{ matrix.nroff == 'no-roff' && 'true' || matrix.nroff }}
         make -j 2 test
 
+  dragonflybsd:
+    name: >
+      DragonFlyBSD
+      ${{ matrix.osversion }}
+      ${{ matrix.abi == '64' && ' ' || matrix.abi }}
+      ${{ matrix.nroff == 'nroff' && ' ' || matrix.nroff }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        osversion: ["6.4.0"]
+        abi: [64]
+        nroff: ["mandoc", "no-roff"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build and Test
+      uses: vmactions/dragonflybsd-vm@v1
+      with:
+        release: ${{ matrix.osversion }}
+        usesh: true
+        prepare: |
+          set -e
+          pkg install -y pkgconf check
+        run: |
+          set -e
+          echo "cc -m${{ matrix.abi }} -O2" > conf-cc
+          echo "cc -m${{ matrix.abi }} -s" > conf-ld
+          make -j 2 it man NROFF=${{ matrix.nroff == 'no-roff' && 'true' || matrix.nroff }}
+          make -j 2 test
+
   freebsd:
     name: >
       FreeBSD

--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -182,7 +182,7 @@ jobs:
   solaris:
     name: >
       Solaris
-      ${{ matrix.osversion }}
+      ${{ matrix.osdisplayversion }}
       ${{ matrix.abi == '64' && ' ' || matrix.abi }}
       ${{ matrix.nroff == 'nroff' && ' ' || matrix.nroff }}
       ${{ matrix.nroff == 'no-roff' && 'no-obsolete' || ' ' }}
@@ -190,7 +190,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osversion: ["11.4"] # "11.4-gcc"
+        osversion: ["11.4-gcc"]
+        osdisplayversion: ["11.4"]
         abi: [64] # 32
         nroff: ["nroff", "no-roff"]
         libcheck: ["0.15.2"]
@@ -204,7 +205,7 @@ jobs:
         usesh: true
         prepare: |
           set -e
-          pkgutil -y -i gcc4core pkgconfig curl
+          pkgutil -y -i pkgconfig curl
           curl -L -O https://github.com/libcheck/check/releases/download/${{ matrix.libcheck }}/check-${{ matrix.libcheck }}.tar.gz
           gunzip check-${{ matrix.libcheck }}.tar.gz
           tar -xvf check-${{ matrix.libcheck }}.tar


### PR DESCRIPTION
Potential platforms that are available via GitHub Actions, I've tested recently with another project, and will not be adding to our matrix at present:

1. OpenBSD/arm64 and FreeBSD/arm64 (7.4 and 13.2 are latest at time of writing), via @cross-platform-actions:
    - In my testing for another project, they take an order of magnitude longer to run
    - We have a nonzero number of arm64 builds already, thanks to Alpine
2. OmniOS, via @vmactions:
    - As with Solaris, there's no native package of [check](https://libcheck.github.io/check/)
    - I'm not eager to be hand-building `libcheck` in two places
    - Building on Oracle Solaris means our chances of building on Illumos are pretty good

Once arm64 OpenBSD, FreeBSD, and (hopefully soon) NetBSD are running acceptably fast under the new `macos-14` host that's aarch64, we should add them.

Once our Solaris builder is caching our hand-built `libcheck`, we can reconsider the cost/benefit of adding OmniOS.