### PR TITLE
instchown: operate on fds, not filenames.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -712,12 +712,12 @@ compile instcheck.c strerr.h error.h readwrite.h hier.h
 
 instchown: \
 load instchown.o instuidgid.o fifo.o hier.o auto_qmail.o auto_split.o \
-ids.a strerr.a substdio.a error.a str.a env.a fs.a stralloc.a
+ids.a strerr.a substdio.a error.a str.a env.a fs.a open.a stralloc.a
 	./load instchown instuidgid.o fifo.o hier.o auto_qmail.o auto_split.o \
-	ids.a strerr.a substdio.a error.a str.a env.a fs.a stralloc.a
+	ids.a strerr.a substdio.a error.a str.a env.a fs.a open.a stralloc.a
 
 instchown.o: \
-compile instchown.c strerr.h error.h exit.h hier.h
+compile instchown.c env.h open.h stralloc.h strerr.h error.h hier.h
 	./compile instchown.c
 
 instfiles.o: \

--- a/instfiles.c
+++ b/instfiles.c
@@ -103,6 +103,7 @@ void c(char *home, char *subdir, char *file, uid_t uid, gid_t gid, int mode)
 {
   int fdin;
   int fdout;
+  int iscatdir = (0 == strncmp(subdir, "man/cat", 7));
   stralloc dh = { 0 };
 
   if (fchdir(fdsourcedir) == -1)
@@ -111,13 +112,13 @@ void c(char *home, char *subdir, char *file, uid_t uid, gid_t gid, int mode)
   fdin = open_read(file);
   if (fdin == -1) {
     /* silently ignore missing catman pages */
-    if (errno == error_noent && strncmp(subdir, "man/cat", 7) == 0)
+    if (errno == error_noent && iscatdir)
       return;
     strerr_die4sys(111,FATAL,"unable to read ",file,": ");
   }
 
   /* if the user decided to build only dummy catman pages then don't install */
-  if (strncmp(subdir, "man/cat", 7) == 0) {
+  if (iscatdir) {
     struct stat st;
     if (fstat(fdin, &st) != 0)
       strerr_die4sys(111,FATAL,"unable to stat ",file,": ");


### PR DESCRIPTION
The previous code had been flagged by CodeQL as "TOCTOU". It's not -- at worst, it's time-of-chown to time-of-chmod -- but this will run more efficiently (and make the warnings go away).

Tested like so:

```sh
#!/bin/sh

set -e

for i in true mandoc; do
	sudo rm -rf /var/tmp/qmail-staging $(head -1 conf-qmail)
	make clean
	make -j 4 it man NROFF=$i test
	env DESTDIR=/var/tmp/qmail-staging make package
	sudo env DESTDIR=/var/tmp/qmail-staging ./instchown
	sudo make package
	sudo ./instchown
	sudo ./instcheck
done
```