### PR TITLE
autobuilds: add Fedora Rawhide, drop OpenBSD 7.2

### DIFF
--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -189,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osversion: ["7.4", "7.3", "7.2"]
+        osversion: ["7.4", "7.3"]
         abi: [64] # 32
         nroff: ["mandoc", "no-roff"]
     steps:

--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -73,14 +73,14 @@ jobs:
       rawhide
       ${{ matrix.abi == '64' && ' ' || matrix.abi }}
       ${{ matrix.nroff == 'nroff' && ' ' || matrix.nroff }}
-      ${{ matrix.cflags == '' && ' ' || 'max-OBS-flags' }}
+      ${{ matrix.cflags == '' && ' ' || 'max-OBS-flags-and-Werror' }}
     runs-on: ubuntu-latest
     container: fedora:rawhide
     strategy:
       fail-fast: false
       matrix:
         abi: [64]
-        cflags: ["-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"]
+        cflags: ["-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer  -Wshadow -Werror=deprecated-declarations -Werror=implicit-function-declaration -Werror=parentheses -Werror=dangling-else -Werror=pointer-sign"]
         ldflags: ["-Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -Wl,--build-id=sha1"]
         nroff: ["groff", "no-roff"]
     steps:

--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -67,6 +67,34 @@ jobs:
           make -j 2 it man NROFF=${{ matrix.nroff == 'no-roff' && 'true' || matrix.nroff }}
           make -j 2 test
 
+  fedora:
+    name: >
+      Fedora
+      rawhide
+      ${{ matrix.abi == '64' && ' ' || matrix.abi }}
+      ${{ matrix.nroff == 'nroff' && ' ' || matrix.nroff }}
+      ${{ matrix.cflags == '' && ' ' || 'max-OBS-flags' }}
+    runs-on: ubuntu-latest
+    container: fedora:rawhide
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [64]
+        cflags: ["-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"]
+        ldflags: ["-Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -Wl,--build-id=sha1"]
+        nroff: ["groff", "no-roff"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build and Test
+      run: |
+        set -e
+        dnf -y install gcc make groff pkgconf check check-devel
+        echo "cc -m${{ matrix.abi }} -O2 ${{ matrix.cflags }}" > conf-cc
+        echo "cc -m${{ matrix.abi }} -s ${{ matrix.ldflags }}" > conf-ld
+        make -j 2 it man NROFF=${{ matrix.nroff == 'no-roff' && 'true' || matrix.nroff }}
+        make -j 2 test
+
   freebsd:
     name: >
       FreeBSD


### PR DESCRIPTION
Open Build Service gives a build error with Fedora Rawhide, gcc 14, and these build flags:

```
[   20s] + CFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer '
[   20s] + export CFLAGS
[   20s] + CXXFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer '
[   20s] + export CXXFLAGS
[   20s] + FFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -I/usr/lib64/gfortran/modules '
[   20s] + export FFLAGS
[   20s] + FCFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -I/usr/lib64/gfortran/modules '
[   20s] + export FCFLAGS
[   20s] + VALAFLAGS=-g
[   20s] + export VALAFLAGS
[   20s] + RUSTFLAGS='-Copt-level=3 -Cdebuginfo=2 -Ccodegen-units=1 -Cstrip=none -Cforce-frame-pointers=yes -Clink-arg=-specs=/usr/lib/rpm/redhat/redhat-package-notes'
[   20s] + export RUSTFLAGS
[   20s] + LDFLAGS='-Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1 -specs=/usr/lib/rpm/redhat/redhat-package-notes '
[   20s] + export LDFLAGS
```

The error:

```
+ make -s it man NROFF=true
[   21s] seek_cur.c: In function ‘seek_cur’:
[   21s] seek_cur.c:7:10: error: implicit declaration of function ‘lseek’ [-Wimplicit-function-declaration]
[   21s]     7 | { return lseek(fd,(off_t) 0,CUR); }
[   21s]       |          ^~~~~
[   21s] make: *** [Makefile:1711: seek_cur.o] Error 1
```

This PR adds Fedora Rawhide (with nearly all of the same flags) to our build matrix, but does not reproduce the error seen on OBS.

(Also, OpenBSD 7.2 is no longer available from its CDN, so I'm removing it from our build matrix. I've already removed it from our branch protection rules.)