### PR TITLE
clean up interface of substdio functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1830,7 +1830,7 @@ compile substdio_copy.c substdio.h
 	./compile substdio_copy.c
 
 substdo.o: \
-compile substdo.c substdio.h str.h byte.h error.h
+compile substdo.c substdio.h byte.h error.h
 	./compile substdo.c
 
 syslog.lib: \

--- a/substdio.h
+++ b/substdio.h
@@ -18,7 +18,7 @@ typedef struct substdio {
 
 extern void substdio_fdbuf(substdio *s, ssize_t (*op)(), int fd, char *buf, int len);
 
-extern int substdio_flush();
+extern int substdio_flush(substdio *s);
 extern int substdio_put(substdio *s, char *buf, size_t len);
 extern int substdio_bput(substdio *s, char *buf, size_t len);
 extern int substdio_putflush(substdio *s, char *buf, size_t len);

--- a/substdio.h
+++ b/substdio.h
@@ -1,6 +1,7 @@
 #ifndef SUBSTDIO_H
 #define SUBSTDIO_H
 
+#include <string.h>
 #include <sys/types.h>
 
 #include "deprecated.h"
@@ -21,9 +22,21 @@ extern int substdio_flush();
 extern int substdio_put(substdio *s, char *buf, size_t len);
 extern int substdio_bput(substdio *s, char *buf, size_t len);
 extern int substdio_putflush(substdio *s, char *buf, size_t len);
-extern int substdio_puts();
-extern int substdio_bputs();
-extern int substdio_putsflush();
+
+static inline int substdio_puts(substdio *s, char *buf)
+{
+  return substdio_put(s, buf, strlen(buf));
+}
+
+static inline int substdio_bputs(substdio *s, char *buf)
+{
+  return substdio_bput(s, buf, strlen(buf));
+}
+
+static inline int substdio_putsflush(substdio *s, char *buf)
+{
+  return substdio_putflush(s, buf, strlen(buf));
+}
 
 extern ssize_t substdio_get(substdio *s, char *buf, size_t len);
 #ifdef DEPRECATED_FUNCTIONS_AVAILABLE

--- a/substdio.h
+++ b/substdio.h
@@ -19,21 +19,21 @@ typedef struct substdio {
 extern void substdio_fdbuf(substdio *s, ssize_t (*op)(), int fd, char *buf, int len);
 
 extern int substdio_flush(substdio *s);
-extern int substdio_put(substdio *s, char *buf, size_t len);
-extern int substdio_bput(substdio *s, char *buf, size_t len);
-extern int substdio_putflush(substdio *s, char *buf, size_t len);
+extern int substdio_put(substdio *s, const char *buf, size_t len);
+extern int substdio_bput(substdio *s, const char *buf, size_t len);
+extern int substdio_putflush(substdio *s, const char *buf, size_t len);
 
-static inline int substdio_puts(substdio *s, char *buf)
+static inline int substdio_puts(substdio *s, const char *buf)
 {
   return substdio_put(s, buf, strlen(buf));
 }
 
-static inline int substdio_bputs(substdio *s, char *buf)
+static inline int substdio_bputs(substdio *s, const char *buf)
 {
   return substdio_bput(s, buf, strlen(buf));
 }
 
-static inline int substdio_putsflush(substdio *s, char *buf)
+static inline int substdio_putsflush(substdio *s, const char *buf)
 {
   return substdio_putflush(s, buf, strlen(buf));
 }

--- a/substdo.c
+++ b/substdo.c
@@ -1,5 +1,4 @@
 #include "substdio.h"
-#include "str.h"
 #include "byte.h"
 #include "error.h"
 
@@ -75,19 +74,4 @@ int substdio_putflush(substdio *s, char *buf, size_t len)
 {
   if (substdio_flush(s) == -1) return -1;
   return allwrite(s->op,s->fd,buf,len);
-}
-
-int substdio_bputs(substdio *s, char *buf)
-{
-  return substdio_bput(s,buf,str_len(buf));
-}
-
-int substdio_puts(substdio *s, char *buf)
-{
-  return substdio_put(s,buf,str_len(buf));
-}
-
-int substdio_putsflush(substdio *s, char *buf)
-{
-  return substdio_putflush(s,buf,str_len(buf));
 }

--- a/substdo.c
+++ b/substdo.c
@@ -2,7 +2,7 @@
 #include "byte.h"
 #include "error.h"
 
-static int allwrite(ssize_t (*op)(int,const char*,size_t), int fd, char *buf, size_t len)
+static int allwrite(ssize_t (*op)(int,const char*,size_t), int fd, const char *buf, size_t len)
 {
   ssize_t w;
 
@@ -29,7 +29,7 @@ int substdio_flush(substdio *s)
   return allwrite(s->op,s->fd,s->x,p);
 }
 
-int substdio_bput(substdio *s, char *buf, size_t len)
+int substdio_bput(substdio *s, const char *buf, size_t len)
 {
   unsigned int n;
  
@@ -46,7 +46,7 @@ int substdio_bput(substdio *s, char *buf, size_t len)
   return 0;
 }
 
-int substdio_put(substdio *s, char *buf, size_t len)
+int substdio_put(substdio *s, const char *buf, size_t len)
 {
   unsigned int n = s->n; /* how many bytes to write in next chunk */
  
@@ -70,7 +70,7 @@ int substdio_put(substdio *s, char *buf, size_t len)
   return 0;
 }
 
-int substdio_putflush(substdio *s, char *buf, size_t len)
+int substdio_putflush(substdio *s, const char *buf, size_t len)
 {
   if (substdio_flush(s) == -1) return -1;
   return allwrite(s->op,s->fd,buf,len);

--- a/substdo.c
+++ b/substdo.c
@@ -2,7 +2,7 @@
 #include "byte.h"
 #include "error.h"
 
-static int allwrite(ssize_t (*op)(), int fd, char *buf, size_t len)
+static int allwrite(ssize_t (*op)(int,const char*,size_t), int fd, char *buf, size_t len)
 {
   ssize_t w;
 


### PR DESCRIPTION
Get rid of declaration without arguments in the header, as that causes warnings in most recent compilers. While at it clean up a bit more.

I'm not aware of any patch that modifies substdio.h or any of it's functions, so I think this is safe.