### PR TITLE
always use the passed fd in generated saferead() and safewrite() functions

### DIFF
--- a/qmail-pop3d.c
+++ b/qmail-pop3d.c
@@ -24,8 +24,8 @@ void die() { _exit(0); }
 
 extern int rename(const char *, const char *);
 
-GEN_SAFE_TIMEOUTREAD(saferead,1200,fd,die())
-GEN_SAFE_TIMEOUTWRITE(safewrite,1200,fd,die())
+GEN_SAFE_TIMEOUTREAD(saferead,1200,die())
+GEN_SAFE_TIMEOUTWRITE(safewrite,1200,die())
 
 char sserrbuf[128];
 substdio sserr = SUBSTDIO_FDBUF(safewrite,2,sserrbuf,sizeof(sserrbuf));

--- a/qmail-popup.c
+++ b/qmail-popup.c
@@ -18,8 +18,8 @@
 
 void _noreturn_ die() { _exit(1); }
 
-GEN_SAFE_TIMEOUTREAD(saferead,1200,fd,die())
-GEN_SAFE_TIMEOUTWRITE(safewrite,1200,fd,die())
+GEN_SAFE_TIMEOUTREAD(saferead,1200,die())
+GEN_SAFE_TIMEOUTWRITE(safewrite,1200,die())
 
 char ssoutbuf[128];
 substdio ssout = SUBSTDIO_FDBUF(safewrite,1,ssoutbuf,sizeof(ssoutbuf));

--- a/qmail-qmqpc.c
+++ b/qmail-qmqpc.c
@@ -35,8 +35,8 @@ void die_format() { _exit(91); }
 int lasterror = 55;
 int qmqpfd;
 
-GEN_SAFE_TIMEOUTREAD(saferead,60,qmqpfd,die_conn())
-GEN_SAFE_TIMEOUTWRITE(safewrite,60,qmqpfd,die_conn())
+GEN_SAFE_TIMEOUTREAD(saferead,60,fd,die_conn())
+GEN_SAFE_TIMEOUTWRITE(safewrite,60,fd,die_conn())
 
 char buf[1024];
 substdio to = SUBSTDIO_FDBUF(safewrite,-1,buf,sizeof(buf));
@@ -97,6 +97,9 @@ char *server;
 
   qmqpfd = socket(AF_INET,SOCK_STREAM,0);
   if (qmqpfd == -1) die_socket();
+
+  to.fd = qmqpfd;
+  from.fd = qmqpfd;
 
   if (timeoutconn(qmqpfd,&ip,PORT_QMQP,10) != 0) {
     lasterror = 73;

--- a/qmail-qmqpc.c
+++ b/qmail-qmqpc.c
@@ -35,8 +35,8 @@ void die_format() { _exit(91); }
 int lasterror = 55;
 int qmqpfd;
 
-GEN_SAFE_TIMEOUTREAD(saferead,60,fd,die_conn())
-GEN_SAFE_TIMEOUTWRITE(safewrite,60,fd,die_conn())
+GEN_SAFE_TIMEOUTREAD(saferead,60,die_conn())
+GEN_SAFE_TIMEOUTWRITE(safewrite,60,die_conn())
 
 char buf[1024];
 substdio to = SUBSTDIO_FDBUF(safewrite,-1,buf,sizeof(buf));

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -108,8 +108,8 @@ int timeoutconnect = 60;
 int smtpfd;
 int timeout = 1200;
 
-GEN_SAFE_TIMEOUTREAD(saferead,timeout,fd,dropped())
-GEN_SAFE_TIMEOUTWRITE(safewrite,timeout,fd,dropped())
+GEN_SAFE_TIMEOUTREAD(saferead,timeout,dropped())
+GEN_SAFE_TIMEOUTWRITE(safewrite,timeout,dropped())
 
 char inbuf[1024];
 substdio ssin = SUBSTDIO_FDBUF(read,0,inbuf,sizeof(inbuf));

--- a/qmail-remote.c
+++ b/qmail-remote.c
@@ -108,8 +108,8 @@ int timeoutconnect = 60;
 int smtpfd;
 int timeout = 1200;
 
-GEN_SAFE_TIMEOUTREAD(saferead,timeout,smtpfd,dropped())
-GEN_SAFE_TIMEOUTWRITE(safewrite,timeout,smtpfd,dropped())
+GEN_SAFE_TIMEOUTREAD(saferead,timeout,fd,dropped())
+GEN_SAFE_TIMEOUTWRITE(safewrite,timeout,fd,dropped())
 
 char inbuf[1024];
 substdio ssin = SUBSTDIO_FDBUF(read,0,inbuf,sizeof(inbuf));
@@ -393,7 +393,10 @@ int main(int argc, char **argv)
  
     smtpfd = socket(AF_INET,SOCK_STREAM,0);
     if (smtpfd == -1) temp_oserr();
- 
+
+    smtpto.fd = smtpfd;
+    smtpfrom.fd = smtpfd;
+
     if (timeoutconn(smtpfd,&ip.ix[i].ip,(unsigned int) port,timeoutconnect) == 0) {
       tcpto_err(&ip.ix[i].ip,0);
       partner = ip.ix[i].ip;

--- a/qmail-smtpd.c
+++ b/qmail-smtpd.c
@@ -30,7 +30,7 @@
 unsigned int databytes = 0;
 int timeout = 1200;
 
-GEN_SAFE_TIMEOUTWRITE(safewrite,timeout,fd,_exit(1))
+GEN_SAFE_TIMEOUTWRITE(safewrite,timeout,_exit(1))
 
 char ssoutbuf[512];
 substdio ssout = SUBSTDIO_FDBUF(safewrite,1,ssoutbuf,sizeof(ssoutbuf));

--- a/timeoutread.h
+++ b/timeoutread.h
@@ -5,11 +5,11 @@
 
 extern ssize_t timeoutread(int t, int fd, char *buf, size_t len);
 
-#define GEN_SAFE_TIMEOUTREAD(funcname,tout,readfd,doexit) \
+#define GEN_SAFE_TIMEOUTREAD(funcname,tout,doexit) \
 ssize_t funcname(int fd, void *buf, size_t len) \
 { \
   ssize_t r; \
-  r = timeoutread(tout,readfd,buf,len); \
+  r = timeoutread(tout,fd,buf,len); \
   if (r == 0 || r == -1) doexit; \
   return r; \
 }

--- a/timeoutwrite.h
+++ b/timeoutwrite.h
@@ -5,11 +5,11 @@
 
 extern ssize_t timeoutwrite(int t, int fd, const void *buf, size_t len);
 
-#define GEN_SAFE_TIMEOUTWRITE(funcname,tout,writefd,doexit) \
+#define GEN_SAFE_TIMEOUTWRITE(funcname,tout,doexit) \
 ssize_t funcname(int fd, const void *buf, size_t len) \
 { \
   ssize_t r; \
-  r = timeoutwrite(tout,writefd,buf,len); \
+  r = timeoutwrite(tout,fd,buf,len); \
   if (r == 0 || r == -1) doexit; \
   return r; \
 }


### PR DESCRIPTION
Fixes #270.

There were situations where the generated functions would ignore the fd that was passed as their argument because if was always "-1". This happened when the substdio was statically initialized but a socket was dynamically allocated at runtime and was actually used for communication. Update the substdio when the socket is known, and then just use the passed fd.