### PR TITLE
auto-*: rename local puts() function

### DIFF
--- a/auto-int.c
+++ b/auto-int.c
@@ -7,8 +7,7 @@
 char buf1[256];
 substdio ss1 = SUBSTDIO_FDBUF(write,1,buf1,sizeof(buf1));
 
-void puts(s)
-char *s;
+static void putstr(const char *s)
 {
   if (substdio_puts(&ss1,s) == -1) _exit(111);
 }
@@ -29,11 +28,11 @@ int main(int argc, char **argv)
   scan_ulong(value,&num);
   strnum[fmt_ulong(strnum,num)] = 0;
 
-  puts("int ");
-  puts(name);
-  puts(" = ");
-  puts(strnum);
-  puts(";\n");
+  putstr("int ");
+  putstr(name);
+  putstr(" = ");
+  putstr(strnum);
+  putstr(";\n");
   if (substdio_flush(&ss1) == -1) return 111;
   return 0;
 }

--- a/auto-int8.c
+++ b/auto-int8.c
@@ -7,8 +7,7 @@
 char buf1[256];
 substdio ss1 = SUBSTDIO_FDBUF(write,1,buf1,sizeof(buf1));
 
-void puts(s)
-char *s;
+static void putstr(const char *s)
 {
   if (substdio_puts(&ss1,s) == -1) _exit(111);
 }
@@ -29,11 +28,11 @@ int main(int argc, char **argv)
   scan_8long(value,&num);
   strnum[fmt_ulong(strnum,num)] = 0;
 
-  puts("int ");
-  puts(name);
-  puts(" = ");
-  puts(strnum);
-  puts(";\n");
+  putstr("int ");
+  putstr(name);
+  putstr(" = ");
+  putstr(strnum);
+  putstr(";\n");
   if (substdio_flush(&ss1) == -1) return 111;
   return 0;
 }

--- a/auto-str.c
+++ b/auto-str.c
@@ -6,8 +6,7 @@
 char buf1[256];
 substdio ss1 = SUBSTDIO_FDBUF(write,1,buf1,sizeof(buf1));
 
-void puts(s)
-char *s;
+static void putstr(const char *s)
 {
   if (substdio_puts(&ss1,s) == -1) _exit(111);
 }
@@ -36,25 +35,25 @@ int main(int argc, char **argv)
   value = argv[2];
   if (!value) return 100;
 
-  puts("char ");
-  puts(name);
-  puts("[] = \"\\\n");
+  putstr("char ");
+  putstr(name);
+  putstr("[] = \"\\\n");
 
   while ((ch = *value++)) {
     if (is_legible(ch)) {
       if (substdio_put(&ss1, (char *)&ch, 1) == -1)
         _exit(111);
     } else {
-      puts("\\");
+      putstr("\\");
       octal[3] = 0;
       octal[2] = '0' + (ch & 7); ch >>= 3;
       octal[1] = '0' + (ch & 7); ch >>= 3;
       octal[0] = '0' + (ch & 7);
-      puts(octal);
+      putstr(octal);
     }
   }
 
-  puts("\\\n\";\n");
+  putstr("\\\n\";\n");
   if (substdio_flush(&ss1) == -1) return 111;
   return 0;
 }


### PR DESCRIPTION
This fixes warnings like the following:

>  auto-int8.c:10:6: warning: conflicting types for built-in function ‘puts’ [-Wbuiltin-declaration-mismatch]

Rename the function to putstr() and give it a proper interface when touching it anyway.

I have not touched the other 3 instances in qmail-inject.c, qmail-pop3d.c, and qmail-popup.c. I see a possibility for collision with existing patches there, but I'm not aware that anyone ever modified the auto-* files in any patch.