### PR TITLE
Catch up to master -> main branch rename.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+    branches: [main, ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 18 * * 2'
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ release-commit:
 	git commit -S -m 'This is notqmail $(RELEASE_VERSION).' CHANGES.md COPYRIGHT Makefile
 
 release-copyright:
-	[ `git diff master COPYRIGHT | wc -l` -gt 0 ] || \
+	[ `git diff main COPYRIGHT | wc -l` -gt 0 ] || \
 	( previous=`grep version: CHANGES.md | grep -v '$(RELEASE_VERSION)\.$$' | head -n 1 | sed -e 's|.* ||' -e 's|\.$$||'`; \
 	echo; echo notqmail-$(RELEASE_VERSION); \
 	yes - | head -n `echo notqmail-$(RELEASE_VERSION) | tr -d '\n' | wc -c` | tr -d '\n'; \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://img.shields.io/github/actions/workflow/status/notqmail/notqmail/platform-builders.yml)](https://github.com/notqmail/notqmail/actions/workflows/platform-builders.yml?query=branch%3Amaster)
+[![Build status](https://img.shields.io/github/actions/workflow/status/notqmail/notqmail/platform-builders.yml)](https://github.com/notqmail/notqmail/actions/workflows/platform-builders.yml?query=branch%3Amain)
 
 # notqmail
 


### PR DESCRIPTION
Keep our (still pretty minimal) release-process automation working with the new branch name.