### PR TITLE
commands: decouple command processing and IO

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -5,38 +5,26 @@
 #include "str.h"
 #include "case.h"
 
-static stralloc cmd = {0};
-
-int commands(ss,c)
-substdio *ss;
-struct commands *c;
+void execute_command(char *line, size_t len, const struct command *cmds)
 {
-  unsigned int i;
+  size_t whitespace_pos, i;
   char *arg;
+  /* trim newlines and carriage returns */
+  while (len > 0 && (line[len - 1] == '\r' || line[len - 1] == '\n'))
+    len--;
 
-  for (;;) {
-    if (!stralloc_copys(&cmd,"")) return -1;
+  line[len] = '\0';
+  whitespace_pos = str_chr(line, ' ');
+  arg = line + whitespace_pos;
+  while (*arg == ' ')
+    arg++;
 
-    for (;;) {
-      int j;
-      if (!stralloc_readyplus(&cmd,1)) return -1;
-      j = substdio_get(ss,cmd.s + cmd.len,1);
-      if (j != 1) return j;
-      if (cmd.s[cmd.len] == '\n') break;
-      ++cmd.len;
-    }
-
-    if (cmd.len > 0) if (cmd.s[cmd.len - 1] == '\r') --cmd.len;
-
-    cmd.s[cmd.len] = 0;
-
-    i = str_chr(cmd.s,' ');
-    arg = cmd.s + i;
-    while (*arg == ' ') ++arg;
-    cmd.s[i] = 0;
-
-    for (i = 0;c[i].text;++i) if (case_equals(c[i].text,cmd.s)) break;
-    c[i].fun(arg);
-    if (c[i].flush) c[i].flush();
+  for (i = 0; cmds[i].text; i++) {
+    if (!case_diffb(cmds[i].text, whitespace_pos, line))
+      break;
   }
+
+  cmds[i].fun(arg, cmds[i].data);
+  if (cmds[i].flush) /* TODO does it belong here? */
+    cmds[i].flush();
 }

--- a/commands.h
+++ b/commands.h
@@ -1,12 +1,15 @@
 #ifndef COMMANDS_H
 #define COMMANDS_H
 
-struct commands {
+#include <stddef.h>
+
+struct command {
   char *text;
-  void (*fun)();
-  void (*flush)();
+  void (*fun)(char *arg, void *data);
+  void (*flush)(void);
+  void *data;
 } ;
 
-extern int commands();
+extern void execute_command(char *line, size_t len, const struct command *cmds);
 
 #endif

--- a/qmail-pop3d.c
+++ b/qmail-pop3d.c
@@ -36,19 +36,19 @@ substdio ssout = SUBSTDIO_FDBUF(safewrite,1,ssoutbuf,sizeof(ssoutbuf));
 char ssinbuf[128];
 substdio ssin = SUBSTDIO_FDBUF(saferead,0,ssinbuf,sizeof(ssinbuf));
 
-void put(buf,len) char *buf; int len;
+void put(char *buf, int len)
 {
   substdio_put(&ssout,buf,len);
 }
-void puts(s) char *s;
+void puts(char *s)
 {
   substdio_puts(&ssout,s);
 }
-void flush()
+void flush(void)
 {
   substdio_flush(&ssout);
 }
-void err(s) char *s;
+void err(char *s)
 {
   puts("-ERR ");
   puts(s);
@@ -56,25 +56,25 @@ void err(s) char *s;
   flush();
 }
 
-void die_nomem() { err("out of memory"); die(); }
-void die_nomaildir() { err("this user has no $HOME/Maildir"); die(); }
-void die_root() {
+void die_nomem(void) { err("out of memory"); die(); }
+void die_nomaildir(void) { err("this user has no $HOME/Maildir"); die(); }
+void die_root(void) {
   substdio_putsflush(&sserr,"qmail-pop3d invoked as uid 0, terminating\n");
   _exit(1);
 }
-void die_scan() { err("unable to scan $HOME/Maildir"); die(); }
+void die_scan(void) { err("unable to scan $HOME/Maildir"); die(); }
 
-void err_syntax() { err("syntax error"); }
-void err_unimpl(arg) char *arg; { err("unimplemented"); }
-void err_deleted() { err("already deleted"); }
-void err_nozero() { err("messages are counted from 1"); }
-void err_toobig() { err("not that many messages"); }
-void err_nosuch() { err("unable to open that message"); }
-void err_nounlink() { err("unable to unlink all deleted messages"); }
+void err_syntax(void) { err("syntax error"); }
+void err_unimpl(char *arg, void *data) { err("unimplemented"); }
+void err_deleted(void) { err("already deleted"); }
+void err_nozero(void) { err("messages are counted from 1"); }
+void err_toobig(void) { err("not that many messages"); }
+void err_nosuch(void) { err("unable to open that message"); }
+void err_nounlink(void) { err("unable to unlink all deleted messages"); }
 
-void okay(arg) char *arg; { puts("+OK \r\n"); flush(); }
+void okay(char *arg, void *data) { puts("+OK \r\n"); flush(); }
 
-void printfn(fn) char *fn;
+void printfn(char *fn)
 {
   fn += 4;
   put(fn,str_chr(fn,':'));
@@ -83,9 +83,7 @@ void printfn(fn) char *fn;
 char strnum[FMT_ULONG];
 stralloc line = {0};
 
-void blast(ssfrom,limit)
-substdio *ssfrom;
-unsigned long limit;
+void blast(substdio *ssfrom, unsigned long limit)
 {
   int match;
   int inheaders = 1;
@@ -120,7 +118,7 @@ unsigned int numm;
 
 int last = 0;
 
-void getlist()
+void getlist(void)
 {
   struct prioq_elt pe;
   struct stat st;
@@ -145,7 +143,7 @@ void getlist()
   }
 }
 
-void pop3_stat(arg) char *arg;
+void pop3_stat(char *arg, void *data)
 {
   unsigned int i;
   unsigned long total;
@@ -160,15 +158,15 @@ void pop3_stat(arg) char *arg;
   flush();
 }
 
-void pop3_rset(arg) char *arg;
+void pop3_rset(char *arg, void *data)
 {
   unsigned int i;
   for (i = 0;i < numm;++i) m[i].flagdeleted = 0;
   last = 0;
-  okay(0);
+  okay(0, 0);
 }
 
-void pop3_last(arg) char *arg;
+void pop3_last(char *arg, void *data)
 {
   puts("+OK ");
   put(strnum,fmt_uint(strnum,last));
@@ -176,7 +174,7 @@ void pop3_last(arg) char *arg;
   flush();
 }
 
-void pop3_quit(arg) char *arg;
+void pop3_quit(char *arg, void *data)
 {
   unsigned int i;
   for (i = 0;i < numm;++i)
@@ -191,11 +189,11 @@ void pop3_quit(arg) char *arg;
 	if (!stralloc_0(&line)) die_nomem();
 	rename(m[i].fn,line.s); /* if it fails, bummer */
       }
-  okay(0);
+  okay(0, 0);
   die();
 }
 
-int msgno(arg) char *arg;
+int msgno(char *arg)
 {
   unsigned long u;
   if (!scan_ulong(arg,&u)) { err_syntax(); return -1; }
@@ -206,19 +204,17 @@ int msgno(arg) char *arg;
   return u;
 }
 
-void pop3_dele(arg) char *arg;
+void pop3_dele(char *arg, void *data)
 {
   int i;
   i = msgno(arg);
   if (i == -1) return;
   m[i].flagdeleted = 1;
   if (i + 1 > last) last = i + 1;
-  okay(0);
+  okay(0, 0);
 }
 
-void list(i,flaguidl)
-int i;
-int flaguidl;
+void list(int i, int flaguidl)
 {
   put(strnum,fmt_uint(strnum,i + 1));
   puts(" ");
@@ -227,7 +223,7 @@ int flaguidl;
   puts("\r\n");
 }
 
-void dolisting(arg,flaguidl) char *arg; int flaguidl;
+void dolisting(char *arg, int flaguidl)
 {
   unsigned int i;
   if (*arg) {
@@ -237,7 +233,7 @@ void dolisting(arg,flaguidl) char *arg; int flaguidl;
     list(i,flaguidl);
   }
   else {
-    okay(0);
+    okay(0, 0);
     for (i = 0;i < numm;++i)
       if (!m[i].flagdeleted)
 	list(i,flaguidl);
@@ -246,12 +242,12 @@ void dolisting(arg,flaguidl) char *arg; int flaguidl;
   flush();
 }
 
-void pop3_uidl(arg) char *arg; { dolisting(arg,1); }
-void pop3_list(arg) char *arg; { dolisting(arg,0); }
+void pop3_uidl(char *arg, void *data) { dolisting(arg,1); }
+void pop3_list(char *arg, void *data) { dolisting(arg,0); }
 
 substdio ssmsg; char ssmsgbuf[1024];
 
-void pop3_top(arg) char *arg;
+void pop3_top(char *arg, void *data)
 {
   int i;
   unsigned long limit;
@@ -266,28 +262,29 @@ void pop3_top(arg) char *arg;
  
   fd = open_read(m[i].fn);
   if (fd == -1) { err_nosuch(); return; }
-  okay(0);
+  okay(0, 0);
   substdio_fdbuf(&ssmsg,read,fd,ssmsgbuf,sizeof(ssmsgbuf));
   blast(&ssmsg,limit);
   close(fd);
 }
 
-struct commands pop3commands[] = {
-  { "quit", pop3_quit, 0 }
-, { "stat", pop3_stat, 0 }
-, { "list", pop3_list, 0 }
-, { "uidl", pop3_uidl, 0 }
-, { "dele", pop3_dele, 0 }
-, { "retr", pop3_top, 0 }
-, { "rset", pop3_rset, 0 }
-, { "last", pop3_last, 0 }
-, { "top", pop3_top, 0 }
-, { "noop", okay, 0 }
-, { 0, err_unimpl, 0 }
+struct command pop3commands[] = {
+  { "quit", pop3_quit, 0, 0 }
+, { "stat", pop3_stat, 0, 0 }
+, { "list", pop3_list, 0, 0 }
+, { "uidl", pop3_uidl, 0, 0 }
+, { "dele", pop3_dele, 0, 0 }
+, { "retr", pop3_top, 0, 0 }
+, { "rset", pop3_rset, 0, 0 }
+, { "last", pop3_last, 0, 0 }
+, { "top", pop3_top, 0, 0 }
+, { "noop", okay, 0, 0 }
+, { 0, err_unimpl, 0, 0 }
 } ;
 
 int main(int argc, char **argv)
 {
+  stralloc line = {0};
   sig_alarmcatch(die);
   sig_pipeignore();
  
@@ -297,7 +294,20 @@ int main(int argc, char **argv)
  
   getlist();
 
-  okay(0);
-  commands(&ssin,pop3commands);
-  die();
+  okay(0, 0);
+  for (;;) {
+    line.len = 0;
+
+    for (;;) {
+      int j;
+      if (!stralloc_readyplus(&line, 1))
+        die_nomem();
+      j = substdio_get(&ssin, line.s + line.len, 1);
+      if (j == 0)
+        die();
+      if (line.s[line.len] == '\n') break;
+      ++line.len;
+    }
+    execute_command(line.s, line.len, pop3commands);
+  }
 }

--- a/qmail-popup.c
+++ b/qmail-popup.c
@@ -27,15 +27,15 @@ substdio ssout = SUBSTDIO_FDBUF(safewrite,1,ssoutbuf,sizeof(ssoutbuf));
 char ssinbuf[128];
 substdio ssin = SUBSTDIO_FDBUF(saferead,0,ssinbuf,sizeof(ssinbuf));
 
-void puts(s) char *s;
+void puts(char *s)
 {
   substdio_puts(&ssout,s);
 }
-void flush()
+void flush(void)
 {
   substdio_flush(&ssout);
 }
-void err(s) char *s;
+void err(char *s)
 {
   puts("-ERR ");
   puts(s);
@@ -43,20 +43,20 @@ void err(s) char *s;
   flush();
 }
 
-void _noreturn_ die_usage() { err("usage: popup hostname subprogram"); die(); }
-void _noreturn_ die_nomem() { err("out of memory"); die(); }
-void _noreturn_ die_pipe() { err("unable to open pipe"); die(); }
-void _noreturn_ die_write() { err("unable to write pipe"); die(); }
-void _noreturn_ die_fork() { err("unable to fork"); die(); }
-void die_childcrashed() { err("aack, child crashed"); }
-void die_badauth() { err("authorization failed"); }
+void _noreturn_ die_usage(void) { err("usage: popup hostname subprogram"); die(); }
+void _noreturn_ die_nomem(void) { err("out of memory"); die(); }
+void _noreturn_ die_pipe(void) { err("unable to open pipe"); die(); }
+void _noreturn_ die_write(void) { err("unable to write pipe"); die(); }
+void _noreturn_ die_fork(void) { err("unable to fork"); die(); }
+void die_childcrashed(void) { err("aack, child crashed"); }
+void die_badauth(void) { err("authorization failed"); }
 
-void err_syntax() { err("syntax error"); }
-void err_wantuser() { err("USER first"); }
-void err_authoriz(arg) char *arg; { err("authorization first"); }
+void err_syntax(void) { err("syntax error"); }
+void err_wantuser(void) { err("USER first"); }
+void err_authoriz(char *arg, void *data) { err("authorization first"); }
 
-void okay(arg) char *arg; { puts("+OK \r\n"); flush(); }
-void _noreturn_ pop3_quit(char *arg) { okay(0); die(); }
+void okay(char *arg, void *data) { puts("+OK \r\n"); flush(); }
+void _noreturn_ pop3_quit(char *arg, void *data) { okay(0, 0); die(); }
 
 
 char unique[FMT_ULONG + FMT_ULONG + 3];
@@ -105,7 +105,7 @@ void _noreturn_ doanddie(char *user,
   if (wait_exitcode(wstat)) die_badauth();
   die();
 }
-void pop3_greet()
+void pop3_greet(void)
 {
   char *s;
   s = unique;
@@ -120,21 +120,21 @@ void pop3_greet()
   puts(">\r\n");
   flush();
 }
-void pop3_user(arg) char *arg;
+void pop3_user(char *arg, void *data)
 {
   if (!*arg) { err_syntax(); return; }
-  okay(0);
+  okay(0, 0);
   seenuser = 1;
   if (!stralloc_copys(&username,arg)) die_nomem(); 
   if (!stralloc_0(&username)) die_nomem(); 
 }
-void pop3_pass(arg) char *arg;
+void pop3_pass(char *arg, void *data)
 {
   if (!seenuser) { err_wantuser(); return; }
   if (!*arg) { err_syntax(); return; }
   doanddie(username.s,username.len,arg);
 }
-void pop3_apop(arg) char *arg;
+void pop3_apop(char *arg, void *apop)
 {
   char *space;
   space = arg + str_chr(arg,' ');
@@ -143,17 +143,18 @@ void pop3_apop(arg) char *arg;
   doanddie(arg,space - arg,space);
 }
 
-struct commands pop3commands[] = {
-  { "user", pop3_user, 0 }
-, { "pass", pop3_pass, 0 }
-, { "apop", pop3_apop, 0 }
-, { "quit", pop3_quit, 0 }
-, { "noop", okay, 0 }
-, { 0, err_authoriz, 0 }
+struct command pop3commands[] = {
+  { "user", pop3_user, 0, 0 }
+, { "pass", pop3_pass, 0, 0 }
+, { "apop", pop3_apop, 0, 0 }
+, { "quit", pop3_quit, 0, 0 }
+, { "noop", okay, 0, 0 }
+, { 0, err_authoriz, 0, 0 }
 } ;
 
 int main(int argc, char **argv)
 {
+  stralloc line = {0};
   sig_alarmcatch(die);
   sig_pipeignore();
  
@@ -163,6 +164,19 @@ int main(int argc, char **argv)
   if (!*childargs) die_usage();
  
   pop3_greet();
-  commands(&ssin,pop3commands);
-  die();
+  for (;;) {
+    line.len = 0;
+
+    for (;;) {
+      int j;
+      if (!stralloc_readyplus(&line, 1))
+        die_nomem();
+      j = substdio_get(&ssin, line.s + line.len, 1);
+      if (j == 0)
+        die();
+      if (line.s[line.len] == '\n') break;
+      ++line.len;
+    }
+    execute_command(line.s, line.len, pop3commands);
+  }
 }


### PR DESCRIPTION
This would allow adding timed reads in pop3d, popup and smtpd

Also add custom data pointer to command handlers to faciliate getting rid of global variables.

Along the way, get rid of K&R function definitions in the related files.