### PR TITLE
quarterly autobuild update

### DIFF
--- a/.github/workflows/check-available-os-versions.sh
+++ b/.github/workflows/check-available-os-versions.sh
@@ -124,7 +124,7 @@ get_known_platform_versions() {
 	Alpine) echo 3.23 ;;
 	DragonFlyBSD) echo 6.4.2 6.4.1 ;;
 	Fedora) echo rawhide ;;
-	FreeBSD) echo 15.0 14.3 14.2 14.1 14.0 13.5 13.4 13.3 13.2 ;;
+	FreeBSD) echo 15.0 14.4 14.3 14.2 14.1 14.0 13.5 13.4 13.3 13.2 ;;
 	macOS) echo 26 15-intel 15 14 ;;
 	NetBSD) echo 10.1 10.0 9.4 9.3 9.2 9.1 9.0 ;;
 	OmniOS) echo r151056 r151054 r151052 r151050 r151048 r151046 ;;

--- a/.github/workflows/check-available-os-versions.sh
+++ b/.github/workflows/check-available-os-versions.sh
@@ -125,7 +125,7 @@ get_known_platform_versions() {
 	DragonFlyBSD) echo 6.4.2 6.4.1 ;;
 	Fedora) echo rawhide ;;
 	FreeBSD) echo 15.0 14.4 14.3 14.2 14.1 14.0 13.5 13.4 13.3 13.2 ;;
-	macOS) echo 26 15-intel 15 14 ;;
+	macOS) echo 26 26-intel 15-intel 15 14 ;;
 	NetBSD) echo 10.1 10.0 9.4 9.3 9.2 9.1 9.0 ;;
 	OmniOS) echo r151056 r151054 r151052 r151050 r151048 r151046 ;;
 	OpenBSD) echo 7.8 7.7 ;;

--- a/.github/workflows/check-available-os-versions.sh
+++ b/.github/workflows/check-available-os-versions.sh
@@ -127,7 +127,7 @@ get_known_platform_versions() {
 	FreeBSD) echo 15.0 14.4 14.3 14.2 14.1 14.0 13.5 13.4 13.3 13.2 ;;
 	macOS) echo 26 26-intel 15-intel 15 14 ;;
 	NetBSD) echo 10.1 10.0 9.4 9.3 9.2 9.1 9.0 ;;
-	OmniOS) echo r151056 r151054 r151052 r151050 r151048 r151046 ;;
+	OmniOS) echo r151056-build r151056 r151054 r151052 r151050 r151048 r151046 ;;
 	OpenBSD) echo 7.8 7.7 ;;
 	Solaris) echo 11.4-gcc-14 11.4-gcc 11.4-clang-19 11.4 ;;
 	Ubuntu) echo 24.04 22.04 slim ;;

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,5 @@
 name: "CodeQL"
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -1,4 +1,5 @@
 name: Build
+permissions: read-all
 
 on:
   push

--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["x86_64", "aarch64"]
-        osversion: ["15.0", "14.3"]
+        osversion: ["15.0", "14.4"]
         abi: ["64"]
         cflags: ["-Wall -Wshadow -Werror=implicit-function-declaration -Werror=deprecated-declarations -Werror=parentheses -Werror=dangling-else -Werror=pointer-sign -Werror=incompatible-library-redeclaration -Werror=empty-body -Werror=pointer-sign"]
         nroff: ["nroff", "no-roff"]

--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osversion: ["26", "15-intel", "14"]
+        osversion: ["26", "26-intel", "14"]
         abi: ["64"]
         warnings: ["-Wall -Wshadow -Werror=implicit-function-declaration -Werror=incompatible-library-redeclaration -Werror=parentheses -Werror=dangling-else -Werror=pointer-sign"]
         cc: ["clang"]

--- a/.github/workflows/platform-builders.yml
+++ b/.github/workflows/platform-builders.yml
@@ -211,7 +211,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osversion: ["r151056"]
+        osversion: ["r151056-build"]
         abi: ["64", "32"]
         cc: ["gcc", "clang"]
         nroff: ["mandoc", "no-roff"]
@@ -225,7 +225,7 @@ jobs:
         usesh: true
         prepare: |
           set -e
-          pkg install developer/gcc14 developer/clang-19
+          pkg install developer/clang-19
           BOOTSTRAP_TAR="bootstrap-trunk-x86_64-20240116.tar.gz"
           curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/${BOOTSTRAP_TAR}
           tar -zxpf ${BOOTSTRAP_TAR} -C /


### PR DESCRIPTION
Bump FreeBSD and macOS; switch OmniOS to the version that includes build-essentials already.

We've been avoiding some updates to platforms with gcc14 or newer. Would be good to try passing `--std=foo` to see if that lets us get on the latest. (And if not, that would lend some urgency to driving down the rest of the warnings.)