### PR TITLE
Autobuild: give sufficient perms for CodeQL analyse.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,7 @@
 name: "CodeQL"
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Previous autobuild update defined missing permissions, but too tightly. This should fix the CodeQL analysis job, and in turn that should resolve the 11 "Security and quality" items.